### PR TITLE
メール再送機能追加、入力フォーム背景色バグ修正

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -43,6 +43,9 @@
   background-color: white;
   font-size: 1.25rem;
 }
+input:-webkit-autofill{
+	box-shadow: 0 0 0px 100px white inset;
+}
 .select-field {
   border: 1px solid #000;
   padding: 4px;

--- a/app/views/users/confirmations/new.html.erb
+++ b/app/views/users/confirmations/new.html.erb
@@ -1,16 +1,20 @@
-<h2><%= t('.resend_confirmation_instructions') %></h2>
+<div class="text-center">
+  <h2 class="mb-8">
+    <span class="header1"><%= t('.resend_confirmation_instructions') %></span>
+    <p>ユーザー登録用のメールを再送します</p>
+  </h2>
 
-<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "users/shared/error_messages", resource: resource %>
+  <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post, class: "form" }) do |f| %>
+    <%= render "users/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
-  </div>
+    <div class="field">
+      <%= f.label :email %><br />
+      <%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email), class: "text-field" %>
+    </div>
 
-  <div class="actions">
-    <%= f.submit t('.resend_confirmation_instructions') %>
-  </div>
-<% end %>
+    <div class="actions text-center">
+      <%= f.submit t('.resend'), class: "btn" %>
+    </div>
+  <% end %>
+</div>
 
-<%= render "users/shared/links" %>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -33,15 +33,21 @@
     </div>
   <% end %>
 
+  <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+    <div  class="mb-8">
+      <%= link_to t(".forgot_your_password"), new_password_path(resource_name), class: "link text-xl" %>
+    </div>
+  <% end %>
+
   <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
     <div class="mb-8">
       <%= link_to t(".sign_up"), new_registration_path(resource_name), class: "link text-xl" %>
     </div>
   <% end %>
 
-  <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+  <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
     <div>
-      <%= link_to t(".forgot_your_password"), new_password_path(resource_name), class: "link text-xl" %>
+      <%= link_to t('.didn_t_receive_confirmation_instructions'), new_confirmation_path(resource_name), class: "link text-xl" %>
     </div>
   <% end %>
 </div>

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -33,7 +33,8 @@ ja:
     confirmations:
       confirmed: メールアドレスが確認できました。
       new:
-        resend_confirmation_instructions: アカウント確認メール再送
+        resend_confirmation_instructions: ユーザー登録メール再送
+        resend: 再送
       send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
       send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
     failure:
@@ -116,7 +117,8 @@ ja:
       new:
         sign_in: ログイン
         sign_up: 新規登録
-        forgot_your_password: パスワードを忘れてしまった場合
+        forgot_your_password: パスワードを忘れましたか？
+        didn_t_receive_confirmation_instructions: ユーザー登録のメールを受け取っていませんか？
       signed_in: ログインしました。
       signed_out: ログアウトしました。
     shared:


### PR DESCRIPTION
## 概要
- ユーザー登録の確認メール再送機能追加
- ブラウザの仕様で入力フォームのオートコンプリート機能で選択した場合に、背景色が変わってしまう問題の対応
---
### 内容
- メール再送機能
  - [x] テンプレートの修正
- 入力フォームの背景色
  - [x] スタイルシートに追記