### PR TITLE
fixed:ユーザー登録時の都道府県・市区町村セレクトボックスバグ修正

### DIFF
--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -19,7 +19,7 @@
         <div class="mytown-selects">
           <%= pf.collection_select :prefecture_id, Prefecture.all, :id, :name_kanji, {}, { class: "select-field", data: { action: "change->prefecture-municipality#loadMunicipalities" }} %>
 
-          <%= pf.collection_select :municipality_id, Municipality.where(prefecture_id: 1).order(:name_kana), :id, :name_kanji, {}, { class: "select-field", data: { prefecture_municipality_target: "municipality" }} %>
+          <%= pf.collection_select :municipality_id, Municipality.where(prefecture_id: pf.object.prefecture_id || 1).order(:name_kana), :id, :name_kanji, {}, { class: "select-field", data: { prefecture_municipality_target: "municipality" }} %>
         </div>
       </div>
     <% end %>


### PR DESCRIPTION
## 概要
- ユーザー登録において、バリデーションエラーが発生したときに都道府県と市区町村がリンクしないバグを修正した。
---
### 内容
- app/views/users/registrations/new.html.erbの市区町村セレクトボックスのリストを都道府県IDから取得するように変更した。