### PR TITLE
MachiRepoモデルのaddress属性追加方法修正

### DIFF
--- a/db/migrate/20250513054105_create_machi_repos.rb
+++ b/db/migrate/20250513054105_create_machi_repos.rb
@@ -8,7 +8,6 @@ class CreateMachiRepos < ActiveRecord::Migration[8.0]
       t.text :description, limit: 500
       t.integer :hotspot_settings, null: false, default: 0
       t.integer :hotspot_area_radius
-      t.string :address, null: false
       t.float :latitude, null: false
       t.float :longitude, null: false
       t.string :image
@@ -16,7 +15,5 @@ class CreateMachiRepos < ActiveRecord::Migration[8.0]
 
       t.timestamps
     end
-
-    add_index :machi_repos, :address
   end
 end

--- a/db/migrate/20250518224346_add_address_to_machi_repos.rb
+++ b/db/migrate/20250518224346_add_address_to_machi_repos.rb
@@ -1,0 +1,6 @@
+class AddAddressToMachiRepos < ActiveRecord::Migration[8.0]
+  def change
+    add_column :machi_repos, :address, :string, null: false
+    add_index :machi_repos, :address
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_05_13_055102) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_18_224346) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -32,13 +32,13 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_13_055102) do
     t.text "description"
     t.integer "hotspot_settings", default: 0, null: false
     t.integer "hotspot_area_radius"
-    t.string "address", null: false
     t.float "latitude", null: false
     t.float "longitude", null: false
     t.string "image"
     t.integer "views_count", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "address", null: false
     t.index ["address"], name: "index_machi_repos_on_address"
     t.index ["user_id"], name: "index_machi_repos_on_user_id"
   end


### PR DESCRIPTION
## 概要
- MachiRepoモデルのaddress属性をロールバックして追加していたが、本番環境ではロールバックをしないため、カラムを追加するマイグレーションファイルを追加して対応した。
---
### 内容
- [x] MachiRepoモデルにaddress属性を追加するマイグレーションファイルの作成