### PR TITLE
MachiRepoモデルにaddress属性を追加したときのNOT NULL属性対応修正

### DIFF
--- a/db/migrate/20250518224346_add_address_to_machi_repos.rb
+++ b/db/migrate/20250518224346_add_address_to_machi_repos.rb
@@ -1,6 +1,16 @@
 class AddAddressToMachiRepos < ActiveRecord::Migration[8.0]
   def change
-    add_column :machi_repos, :address, :string, null: false
+    add_column :machi_repos, :address, :string
     add_index :machi_repos, :address
+
+    # 既存データに仮の値を入れる
+    reversible do |dir|
+      dir.up do
+        execute "UPDATE machi_repos SET address = '不明' WHERE address IS NULL"
+      end
+    end
+
+    # 後からnull 制約を追加(先にやってしまうと既存のデータでNOT NULL制約違反が発生する)
+    change_column_null :machi_repos, :address, false
   end
 end


### PR DESCRIPTION
## 概要
- MachiRepoモデルにNOT NULL制約のあるaddress属性を追加した場合、本番環境の既存のデータでNOT NULL制約違反が発生してしまう。そのため、マイグレーションファイルでカラム追加時に仮の値を追加するように修正した。
---
### 内容
- [x] MachiRepoモデルへのaddress属性追加用マイグレーションファイルの修正をした