### PR TITLE
まちレポ検索SQLの修正

### DIFF
--- a/app/controllers/machi_repos_controller.rb
+++ b/app/controllers/machi_repos_controller.rb
@@ -37,7 +37,7 @@ class MachiReposController < ApplicationController
 
     # "まち"のまちレポ取得
     search_machi_repos_result = @search_form.search_machi_repos
-    @machi_repos_count = search_machi_repos_result.count
+    @machi_repos_count = search_machi_repos_result.length
     @machi_repos = search_machi_repos_result.page(params[:page])
 
     respond_to do |format|

--- a/app/forms/machi_repo_search_form.rb
+++ b/app/forms/machi_repo_search_form.rb
@@ -29,8 +29,8 @@ class MachiRepoSearchForm
     # マップ上のホットスポット表示数分のデータ取得
     scope = scope.limit(display_hotspot_count)
 
-    # N+1問題対応
-    scope.includes(user: :profile).order(created_at: :desc)
+    # N+1問題対応(tagsテーブルはタグ条件でJOIN済み)
+    scope.preload(user: :profile).order(created_at: :desc)
   end
 
   # "まち"のまちレポ検索
@@ -38,8 +38,8 @@ class MachiRepoSearchForm
     scope = MachiRepo.where(address: address)
     # 検索条件付与
     scope = filter_machi_repos(scope)
-    # N+1問題対応
-    scope.includes(:tags, user: :profile).order(created_at: :desc)
+    # N+1問題対応(tagsテーブルはタグ条件でJOIN済み)
+    scope.preload(user: :profile).order(created_at: :desc)
   end
 
   private
@@ -71,7 +71,8 @@ class MachiRepoSearchForm
       if tag_list.present?
         if tag_match_type == "and"
           # and検索
-          scope = scope.joins(:tags)
+          scope = scope
+            .joins(:tags)
             .where(tags: { name: tag_list })
             .group("machi_repos.id")
             .having("COUNT(DISTINCT tags.id) = ?", tag_list.size)

--- a/app/views/machi_repos/_index_map.html.erb
+++ b/app/views/machi_repos/_index_map.html.erb
@@ -59,7 +59,7 @@
   <div class="xl:flex xl:justify-around">
     <section class="text-left xl:w-100">
       <h3 class="header2 mb-4 ">
-        周辺のホットスポット（<%= near_hotspots.size %>件）
+        周辺のホットスポット（<%= near_hotspots.length %>件）
       </h3>
       <!-- Google Map -->
       <div id="map" data-machi-repos--index-target="map" class="mb-4 mx-auto w-full max-w-[400px] aspect-square"></div>


### PR DESCRIPTION
## 概要
- まちレポホームのタグ検索で、and条件のときにエラーが発生していた。おそらくMachiReposテーブルとTagsテーブルの結合が既に行われている状態でincludes(eager_load)によるN+1問題対応をしようとしていたことが原因だと思われる。and条件のときにはGROUP BY句とHAVING句が使用されているため、内部的に複雑化していた模様。PostgreSQL固有のエラーなのかどうかは不明だが、includesに任せるのではなくpreloadを指定しTagsテーブルの無駄なプリロードを削除したところエラーは消えた。
---
### 内容
- [x] まちレポ検索モデル「app/forms/machi_repo_search_form.rb」の修正
- [x] "まち"のまちレポ件数取得を「count」メソッドではなく「length」メソッドに修正 