### PR TITLE
fixed:まちレポ詳細：チャット投稿時の処理を修正した

### DIFF
--- a/app/channels/machi_repo_chat_channel.rb
+++ b/app/channels/machi_repo_chat_channel.rb
@@ -9,19 +9,4 @@ class MachiRepoChatChannel < ApplicationCable::Channel
   def unsubscribed
     # Any cleanup needed when channel is unsubscribed
   end
-
-  def send_chat(data)
-    # 画像データはWebSocket通信では送信できないため、
-    # ここでは画像の保存は行わず、テキストデータのみ取り扱う
-
-    chat = Chat.create(message: data["message"], user: current_user, chatable: @machi_repo)
-    # ビューに返すオブジェクト
-    ActionCable.server.broadcast "machi_repo_chat_#{@machi_repo.id}",
-      {
-        user_id: current_user.id,
-        nickname: current_user.profile.nickname,
-        message: chat.message,
-        time: chat.created_at
-      }
-  end
 end

--- a/app/views/machi_repos/chats/index.html.erb
+++ b/app/views/machi_repos/chats/index.html.erb
@@ -22,15 +22,6 @@
         data-machi-repos--chat-target="chatArea"
         class="invisible"
       >
-        <%# クローン用のデフォルトchatテンプレート %>
-        <div class="hidden">
-          <div data-machi-repos--chat-target="defaultChatMine">
-            <%= render "shared/chat_mine", info_level: @machi_repo.info_level, chat: nil %>
-          </div>
-          <div data-machi-repos--chat-target="defaultChatOthers">
-            <%= render "shared/chat_others", nickname: nil, chat: nil %>
-          </div>
-        </div>
 
         <%# チャット投稿が日を跨いだときのために用意 %>
         <div data-machi-repos--chat-target="defaultChatDate" class="hidden">
@@ -42,8 +33,10 @@
 
         <%# chatの初期表示 %>
         <%# 日付表示 %>
-        <% top_chat_date = @chats.last&.created_at&.to_date || Date.current %>
-        <%= render "chat_date_block", date: top_chat_date %>
+        <% top_chat_date = @chats.last&.created_at&.to_date %>
+        <% if top_chat_date %>
+          <%= render "chat_date_block", date: top_chat_date %>
+        <% end %>
 
         <% previous_date = top_chat_date %>
         <% @chats.reverse_each do |chat| %>

--- a/app/views/machi_repos/chats/render_chat.turbo_stream.erb
+++ b/app/views/machi_repos/chats/render_chat.turbo_stream.erb
@@ -1,0 +1,10 @@
+<%= turbo_stream.append "chat-area" do %>
+  <% unless @other_chats_on_same_day_exist %>
+    <%= render "chat_date_block", date: @chat.created_at.to_date %>
+  <% end %>
+  <% if current_user == @user %>
+    <%= render "shared/chat_mine", info_level: @machi_repo.info_level, chat: @chat %>
+  <% else %>
+    <%= render "shared/chat_others", nickname: @user.profile.nickname, chat: @chat %>
+  <% end %>
+<% end %>

--- a/app/views/shared/_chat_mine.html.erb
+++ b/app/views/shared/_chat_mine.html.erb
@@ -1,5 +1,8 @@
 <!-- 自分のチャット -->
-<div class="chat <%= "#{info_level}" %>">
+<div
+  data-chat-id="<%= chat&.id %>"
+  class="chat <%= "#{info_level}" %>"
+>
   <div class="chat-else">
     <div></div>
     <div class="chat-time">

--- a/app/views/shared/_chat_others.html.erb
+++ b/app/views/shared/_chat_others.html.erb
@@ -1,5 +1,8 @@
 <!-- 誰かのチャット -->
-<div class="chat other">
+<div
+  data-chat-id="<%= chat&.id %>"
+  class="chat other"
+>
   <div class="w-8 aspect-square">
     <%= render "shared/icons/face_icon" %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,9 @@ Rails.application.routes.draw do
       collection do
         get :load_more
       end
+      member do
+        get :render_chat
+      end
     end
   end
 


### PR DESCRIPTION
## 概要
- まちレポのチャット投稿機能をチャネルクラスではなく、コントローラーのアクションで行うように修正した。また、チャットの表示をクライアントサイドで行っていたが、サーバーサイドでpartialを使って行うように修正した。
---
### 内容
- [x] チャネルクラス「app/channels/machi_repo_chat_channel.rb」
- [x] コントローラー「app/controllers/machi_repos/chats_controller.rb」
- [x] stimulusコントローラー「app/javascript/controllers/machi_repos/chat_controller.js 」