### PR TITLE
fixed:トップ画像のimage_tagに「.png」まで記述

### DIFF
--- a/app/views/tops/index.html.erb
+++ b/app/views/tops/index.html.erb
@@ -58,7 +58,7 @@
       </p>
     </div>
     <div id="about-hotspot-image"  class="about-card-content md:flex-1">
-      <%= image_tag "top_map_image" %>
+      <%= image_tag "top_map_image.png" %>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## 概要
- 本番環境で静的画像エラーが出ているため修正してみた。
---
- [x] tops/index.html.erbのimage_tagのsrcに拡張子(.png)が無かったため追記した。