### PR TITLE
fixed:まちレポのチャットにスクロールバー表示

### DIFF
--- a/app/views/machi_repos/chats/index.html.erb
+++ b/app/views/machi_repos/chats/index.html.erb
@@ -13,7 +13,7 @@
   >
     <div
       id="chat-section"
-      class="hide-scrollbar px-2 h-[calc(100vh-440px)] overflow-y-auto transition-all duration-300 ease-in-out md:h-[calc(100vh-355px)]"
+      class="px-2 h-[calc(100vh-440px)] overflow-y-auto transition-all duration-300 ease-in-out md:h-[calc(100vh-355px)]"
       data-chat-scroll-target="container"
       data-machi-repos--chat-target="container"
     >


### PR DESCRIPTION
## 概要
- まちレポ詳細のチャット画面のスクロールバーがちらつくため非表示にしていたが、UXを考えて表示することにした。
---
### 内容
- [x] まちレポ詳細のチャット画面「app/views/machi_repos/chats/index.html.erb」を修正した。