### PR TITLE
fixed:まちレポ詳細：チャット画面のturboキャッシュ無効化

### DIFF
--- a/app/javascript/controllers/chat_scroll_controller.js
+++ b/app/javascript/controllers/chat_scroll_controller.js
@@ -26,6 +26,7 @@ export default class extends Controller {
     this.waitFormImagesLoaded().then(() => {
       // 最初は一番下へスクロール
       this.scrollToBottom();
+      this.containerTarget.classList.remove("invisible");
     });
   }
 

--- a/app/views/machi_repos/chats/index.html.erb
+++ b/app/views/machi_repos/chats/index.html.erb
@@ -1,3 +1,8 @@
+<%# turboのキャッシュが残っていると画面やスクロールがちらつく %>
+<% content_for :head do %>
+  <meta name="turbo-cache-control" content="no-cache">
+<% end %>
+
 <div data-controller="disable-scroll"></div>
 
 <div class="flex flex-col">
@@ -13,7 +18,7 @@
   >
     <div
       id="chat-section"
-      class="px-2 h-[calc(100vh-440px)] overflow-y-auto transition-all duration-300 ease-in-out md:h-[calc(100vh-355px)]"
+      class="invisible px-2 h-[calc(100vh-440px)] overflow-y-auto transition-all duration-300 ease-in-out md:h-[calc(100vh-355px)]"
       data-chat-scroll-target="container"
       data-machi-repos--chat-target="container"
     >


### PR DESCRIPTION
## 概要
- まちレポのチャット画面に遷移したとき、まずturboのキャッシュが表示され、その後正規の画面が表示されると思われる。チャット画面は初期表示時にスクロールを一番下に移動させているため、正規の画面描画によって画面やスクロールがちらついて見えると考えられる。そのため、チャット画面ではturboのキャッシュを無効化した。
---
### 内容
- [x] まちレポチャット画面「app/views/machi_repos/chats/index.html.erb」を修正した。