### PR TITLE
fixed: まちレポ詳細：チャット画像投稿後にメッセージ用テキストエリアつぶれてしまうバグ修正

### DIFF
--- a/app/javascript/controllers/machi_repos/chat_controller.js
+++ b/app/javascript/controllers/machi_repos/chat_controller.js
@@ -178,7 +178,6 @@ export default class extends Controller {
 
       if (response.ok) {
         resetTarget.value = "";
-        this.textareaResizeOutlet?.resize();
       } else {
         const errorData = await response.json();
         console.error("送信失敗", errorData.errors);
@@ -208,6 +207,8 @@ export default class extends Controller {
       formData,
       resetTarget: this.textareaTarget,
     });
+
+    this.textareaResizeOutlet?.resize();
   }
 
   // 画像投稿

--- a/app/views/shared/_chat_mine.html.erb
+++ b/app/views/shared/_chat_mine.html.erb
@@ -19,7 +19,7 @@
     <div class="chat-contents-wrapper">
       <% if chat&.image? %>
         <div class="chat-image-wrapper">
-          <%= image_tag(chat.image.url, class: "chat-image") %>
+          <%= image_tag(chat.image.url, loading: "lazy", class: "chat-image") %>
         </div>
       <% elsif chat&.message.present? %>
         <div class="chat-message-wrapper">

--- a/app/views/shared/_chat_others.html.erb
+++ b/app/views/shared/_chat_others.html.erb
@@ -13,7 +13,7 @@
     </div>
     <% if chat&.image? %>
       <div class="chat-image-wrapper">
-        <%= image_tag(chat.image.url, class: "chat-image") %>
+        <%= image_tag(chat.image.url, loading: "lazy", class: "chat-image") %>
       </div>
     <% elsif chat&.message.present? %>
       <div class="chat-message-wrapper">


### PR DESCRIPTION
## 概要
- チャット画像投稿後にメッセージ用テキストエリアつぶれてしまうバグを修正した。
---
### 内容
- [x] チャット用のstimulusコントローラーを修正した。
- [x] チャット画面の表示軽量化のために、img要素に「loading: lazy」を加えてみた。 