### PR TITLE
fixed:まちレポホーム、新規作成、編集画面デザインモバイル対応

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -273,6 +273,7 @@ input:-webkit-autofill{
   padding: 4px 12px;
   border: 1px solid #000;
   border-radius: 4px 0 0 4px;
+  width: 100%;
   background-color: white;
   font-size: 1.25rem;
 }

--- a/app/views/machi_repos/_form.html.erb
+++ b/app/views/machi_repos/_form.html.erb
@@ -21,11 +21,11 @@
   <div data-controller="tag" class="field">
     <%= form.label :tag_names, "タグ（最大15文字 3つまで）" %>
     <div class="flex">
-      <%= tag.input type: "text", placeholder: "例: 子ども, 通学路, 朝", maxlength: 50, data: { tag_target: "inputTagName", action: "blur->tag#appendTag"  }, class: "map-search-field flex-1" %>
+      <%= tag.input type: "text", placeholder: "例: 子ども, 通学路, 朝", maxlength: 50, data: { tag_target: "inputTagName", action: "blur->tag#appendTag"  }, class: "text-field flex-1" %>
       <%= button_tag type: "button", data: { action: "click->tag#appendTag" }, class: "flex justify-center items-center rounded-tr-sm rounded-br-sm w-10 aspect-square bg-[#3586FF]" do %>
-        <div class="w-8 aspect-square">
+        <span class="w-8 aspect-square">
           <%= render "shared/icons/tag_icon" %>
-        </div>
+        </span>
       <% end %>
     </div>
     <%= form.hidden_field :tag_names, data: { tag_target: "tagNames" } %>
@@ -99,9 +99,9 @@
       <!-- マイタウンアイコン -->
       <div data-action="click->machi-repos--new#mytownShow" class="icon-circle-wrapper">
         <div class="icon-circle">
-          <svg xmlns="http://www.w3.org/2000/svg" height="36px" viewBox="0 -960 960 960" width="36px" fill="#000000">
-            <path d="M370-440h60v-120h100v120h60v-185l-110-73-110 73v185Zm110 281q133-121 196.5-219.5T740-552q0-118-75.5-193T480-820q-109 0-184.5 75T220-552q0 75 65 173.5T480-159Zm0 79Q319-217 239.5-334.5T160-552q0-150 96.5-239T480-880q127 0 223.5 89T800-552q0 100-79.5 217.5T480-80Zm0-480Z"/>
-          </svg>
+          <div class="w-10 aspect-square">
+            <%= render "shared/icons/home_pin_icon" %>
+          </div>
         </div>
         <span class="icon-circle-text">マイタウン</span>
       </div>
@@ -109,9 +109,9 @@
       <!-- 現在地アイコン -->
       <div data-action="click->machi-repos--new#currentLocationShow" class="icon-circle-wrapper">
         <div class="icon-circle">
-          <svg xmlns="http://www.w3.org/2000/svg" height="36px" viewBox="0 -960 960 960" width="36px" fill="#000000">
-            <path d="M450-42v-75q-137-14-228-105T117-450H42v-60h75q14-137 105-228t228-105v-75h60v75q137 14 228 105t105 228h75v60h-75q-14 137-105 228T510-117v75h-60Zm30-134q125 0 214.5-89.5T784-480q0-125-89.5-214.5T480-784q-125 0-214.5 89.5T176-480q0 125 89.5 214.5T480-176Zm0-154q-63 0-106.5-43.5T330-480q0-63 43.5-106.5T480-630q63 0 106.5 43.5T630-480q0 63-43.5 106.5T480-330Zm0-60q38 0 64-26t26-64q0-38-26-64t-64-26q-38 0-64 26t-26 64q0 38 26 64t64 26Zm0-90Z"/>
-          </svg>
+          <div class="w-10 aspect-square">
+            <%= render "shared/icons/my_location_icon" %>
+          </div>
         </div>
         <span class="icon-circle-text">現在地</span>
       </div>
@@ -121,9 +121,9 @@
     <div class="field flex mb-4">
       <%= tag.input type: "text", placeholder: "\"まち\"を入力してください", data: { machi_repos__new_target: "search" }, class: "map-search-field flex-1" %>
       <%= button_tag type: "button", data: { action: "click->machi-repos--new#searchLocationShow" }, class: "flex justify-center items-center rounded-tr-sm rounded-br-sm w-10 aspect-square bg-[#3586FF]" do %>
-        <svg xmlns="http://www.w3.org/2000/svg" height="32px" viewBox="0 -960 960 960" width="32px" fill="#FFFFFF">
-          <path d="M638-511v-1.5 1.5-189 189ZM170-142q-17 9-33.5-1T120-173v-558q0-13 7.5-23t19.5-15l202-71 263 92 178-71q17-8 33.5 1.5T840-788v388q-11-21-26-38.5T780-470v-284l-142 54v189q-16 2-31 5t-29 8v-202l-196-66v540l-212 84Zm10-65 142-54v-505l-142 47v512Zm474-5q38 0 64-26t26-64q0-38-26-64t-64-26q-38 0-64 26t-26 64q0 38 26 64t64 26Zm0 60q-62 0-106-44t-44-106q0-63 44-106.5T654-452q63 0 106.5 43.5T804-302q0 23-6.5 44T779-219l101 101-38 38-101-100q-19 14-40.5 21t-46.5 7ZM322-766v505-505Z"/>
-        </svg>
+      <span class="w-8 aspect-square">
+        <%= render "shared/icons/map_search_icon" %>
+      </span>
       <% end %>
     </div>
 

--- a/app/views/machi_repos/_index_map.html.erb
+++ b/app/views/machi_repos/_index_map.html.erb
@@ -35,9 +35,9 @@
   <div class="field flex mb-4">
     <%= tag.input type: "text", placeholder: "\"まち\"を入力してください", data: { machi_repos__index_target: "search" }, class: "map-search-field flex-1" %>
     <%= button_tag type: "button", data: { action: "click->machi-repos--index#onClickSearchLocationButtton" }, class: "flex justify-center items-center rounded-tr-sm rounded-br-sm bg-[#3586FF]" do %>
-      <div class="w-10 aspect-square">
+      <span class="w-10 aspect-square">
         <%= render "shared/icons/map_search_icon" %>
-      </div>
+      </span>
     <% end %>
   </div>
 

--- a/app/views/shared/_machi_repo_card.html.erb
+++ b/app/views/shared/_machi_repo_card.html.erb
@@ -1,5 +1,5 @@
 <!-- まちレポカード -->
-<div class="w-80 bg-white shadow-md">
+<div class="w-full max-w-80 bg-white shadow-md">
   <%= link_to machi_repo_path(machi_repo), data: { turbo: false }, class: "block" do %>
     <% bg_class = case machi_repo.info_level
       when "share" then "bg-[#37DF6F]"


### PR DESCRIPTION
## 概要
- MVPリリース前にモバイル版を確認して、デザインが崩れている箇所を修正した。
---
### 内容
- [x] まちレポホーム「app/views/machi_repos/index.html.erb」を修正した。
- [x] まちレポ新規作成・編集用フォーム「app/views/machi_repos/_form.html.erb」を修正した。