### PR TITLE
MVPリリース前全体調整(チャット画面)

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -463,3 +463,14 @@ input:-webkit-autofill{
   90%  { transform: translate(-1px, -1px); }
   100% { transform: translate(1px, -1px); }
 }
+
+.bounce {
+  animation: bounce 1.0s infinite linear;
+}
+@keyframes bounce {
+  0% { transform: translate(0, 0) }
+  25% { transform: translate(0, 1px) }
+  50% { transform: translate(0, 0) }
+  50% { transform: translate(0, -1px) }
+  100% { transform: translate(0, 0) }
+}

--- a/app/controllers/machi_repos/chats_controller.rb
+++ b/app/controllers/machi_repos/chats_controller.rb
@@ -1,7 +1,7 @@
 class MachiRepos::ChatsController < ApplicationController
   before_action :set_machi_repo_and_chats, only: [ :index, :load_more ]
 
-  CHAT_PER_PAGE = 12
+  CHAT_PER_PAGE = 15
 
   def index; end
 

--- a/app/javascript/controllers/chat_scroll_controller.js
+++ b/app/javascript/controllers/chat_scroll_controller.js
@@ -36,7 +36,7 @@ export default class extends Controller {
 
   // 無限スクロール用トリガー
   onScroll = () => {
-    if (this.containerTarget.scrollTop < 500) {
+    if (this.containerTarget.scrollTop < 300) {
       // ページ最上部に近づいたとき
       this.loadPreviousPage();
     }

--- a/app/javascript/controllers/chat_scroll_controller.js
+++ b/app/javascript/controllers/chat_scroll_controller.js
@@ -5,6 +5,7 @@ export default class extends Controller {
   static targets = [
     "container",
     "chatArea",
+    "scrollableIcon",
   ];
 
   static values = {
@@ -20,6 +21,7 @@ export default class extends Controller {
     const isLastPage = lastPageMarker?.dataset.lastPage === "true";
     if (!isLastPage) {
       this.containerTarget.addEventListener("scroll", this.onScroll);
+      this.scrollableIconTarget.classList.remove("hidden");
     }
 
     // 画像の表示が終了してから初期表示を行う
@@ -86,6 +88,7 @@ export default class extends Controller {
         const isLastPage = lastPageMarker?.dataset.lastPage === "true";
         if (isLastPage) {
           this.containerTarget.removeEventListener("scroll", this.onScroll);
+          this.scrollableIconTarget.classList.add("hidden");
         }
         this.loading = false;
       });

--- a/app/javascript/controllers/toggle_controller.js
+++ b/app/javascript/controllers/toggle_controller.js
@@ -6,6 +6,17 @@ export default class extends Controller {
     "content",
   ];
 
+  connect() {
+    this.chatSection = document.querySelector("#chat-section");
+    this.chatSectionHeight = this.chatSection.clientHeight;
+    console.log('chatSectionHeight: %s', this.chatSectionHeight);
+    window.addEventListener("resize", () => {
+    });
+  }
+
+  disconnect() {
+  }
+
   toggle(event) {
     const content = this.contentTarget;
     const button = event.currentTarget;

--- a/app/javascript/controllers/toggle_controller.js
+++ b/app/javascript/controllers/toggle_controller.js
@@ -6,21 +6,56 @@ export default class extends Controller {
     "content",
   ];
 
+  BREAK_POINT = 768;
+
   connect() {
     this.chatSection = document.querySelector("#chat-section");
-    this.chatSectionHeight = this.chatSection.clientHeight;
-    console.log('chatSectionHeight: %s', this.chatSectionHeight);
-    window.addEventListener("resize", () => {
-    });
+    if (this.chatSection) {
+      this.windowLastHeight = window.innerHeight;
+      this.windowLastWidth = window.innerWidth;
+      this.chatSectionHeight = this.chatSection.clientHeight;
+
+      window.addEventListener("resize", this.onResizeChatArea);
+    }
   }
 
   disconnect() {
+    if (this.chatSection) {
+      window.removeEventListener("resize", this.onResizeChatArea);
+    }
+  }
+
+  // window幅が変更されたとき、チャット領域の高さを変更する
+  onResizeChatArea = () => {
+    // 表示領域の変更時にチャット領域の高さを修正する
+    const diff = this.windowLastHeight - window.innerHeight;
+    this.windowLastHeight = window.innerHeight;
+    // ウィンドウ高さの差分を追加する
+    this.chatSectionHeight -= diff;
+
+    // レスポンシブ対応
+    if (this.windowLastWidth < this.BREAK_POINT && window.innerWidth >= this.BREAK_POINT) {
+      // 画面幅がモバイル版以上に変わったとき
+      this.contentTarget.style.height = null;
+      this.chatSection.style.height = '';
+      this.windowLastWidth = window.innerWidth;
+    } else if (this.windowLastWidth >= this.BREAK_POINT && window.innerWidth < this.BREAK_POINT) {
+      // 画面幅がモバイル版に変わったとき
+      if (!this.contentTarget.classList.contains("open")) {
+        this.contentTarget.classList.add("open");
+        this.chatSectionHeight -= this.contentTarget.clientHeight;
+        this.chatSection.style.height = `${this.chatSectionHeight}px`;
+      }
+      this.windowLastWidth = window.innerWidth;
+    } else if (window.innerWidth < this.BREAK_POINT) {
+      this.chatSection.style.height = `${this.chatSectionHeight}px`;
+    }
   }
 
   toggle(event) {
     const content = this.contentTarget;
     const button = event.currentTarget;
-    const chatSection = document.querySelector("#chat-section");
+    const chatSection = this.chatSection;
 
     if (content.classList.contains("open")) {
       // 閉じる処理
@@ -33,24 +68,23 @@ export default class extends Controller {
 
       if (chatSection) {
         // contentを閉じた後のチャット領域の高さ
-        this.chatSectionBeforeHeight = chatSection.clientHeight;
-        chatSection.style.height = `calc(${this.chatSectionBeforeHeight}px + ${content.clientHeight}px)`;
+        this.chatSectionHeight = this.chatSectionHeight + content.clientHeight;
+        chatSection.style.height = `calc(${this.chatSectionHeight}px)`;
       }
     } else {
       // 開く処理
       content.classList.add("open");
       content.style.height = `${content.scrollHeight}px`;
 
-      content.addEventListener("transitionend", function handler() {
+      content.addEventListener("transitionend", () => {
         // heightをリセット（autoに戻す）
         content.style.height = null;
-        content.removeEventListener("transitionend", handler);
-      });
-
-      if (chatSection) {
-        // contentを開いた後のチャット領域の高さ
-        chatSection.style.height = `${this.chatSectionBeforeHeight}px`;
-      }
+        if (chatSection) {
+          // contentを開いた後のチャット領域の高さ
+          this.chatSectionHeight -= content.clientHeight;
+          chatSection.style.height = `${this.chatSectionHeight}px`;
+        }
+      }, {once: true});
     }
 
     button.classList.toggle("rotate-180");

--- a/app/javascript/controllers/toggle_controller.js
+++ b/app/javascript/controllers/toggle_controller.js
@@ -10,10 +10,17 @@ export default class extends Controller {
 
   connect() {
     this.chatSection = document.querySelector("#chat-section");
+    // ヘッダー + タイトル + ナビゲーション + 入力フォームの高さ合計
+    this.elseElementHeight = (80 + 36 + 60 + 45);
     if (this.chatSection) {
-      this.windowLastHeight = window.innerHeight;
       this.windowLastWidth = window.innerWidth;
-      this.chatSectionHeight = this.chatSection.clientHeight;
+      this.windowLastHeight = window.innerHeight;
+      if (window.innerWidth < this.BREAK_POINT) {
+        this.chatSectionHeight = window.innerHeight - (this.contentTarget.clientHeight + this.elseElementHeight);
+        this.chatSection.style.height = `${this.chatSectionHeight}px`;
+      } else {
+        this.chatSectionHeight = this.chatSection.clientHeight;
+      }
 
       window.addEventListener("resize", this.onResizeChatArea);
     }
@@ -43,9 +50,9 @@ export default class extends Controller {
       // 画面幅がモバイル版に変わったとき
       if (!this.contentTarget.classList.contains("open")) {
         this.contentTarget.classList.add("open");
-        this.chatSectionHeight -= this.contentTarget.clientHeight;
-        this.chatSection.style.height = `${this.chatSectionHeight}px`;
       }
+      this.chatSectionHeight = window.innerHeight - (this.contentTarget.clientHeight + this.elseElementHeight);
+      this.chatSection.style.height = `${this.chatSectionHeight}px`;
       this.windowLastWidth = window.innerWidth;
     } else if (window.innerWidth < this.BREAK_POINT) {
       this.chatSection.style.height = `${this.chatSectionHeight}px`;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja">
   <head>
-    <title><%= content_for(:title) || "Portfolio" %></title>
+    <title><%= content_for(:title) || "Machi Vigil" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <%= csrf_meta_tags %>

--- a/app/views/machi_repos/_machi_repo_info.html.erb
+++ b/app/views/machi_repos/_machi_repo_info.html.erb
@@ -33,7 +33,7 @@
         </h2>
       </div>
     </div>
-    <nav class="md:fixed md:top-[250px] md:right-[calc(100vw/2+280px)] xl:right-[calc(100vw/2+460px)]">
+    <nav class="md:fixed md:top-[250px] md:left-[50px]">
       <ul class="flex justify-center gap-12 mb-4 md:flex-col">
         <% if controller_name == "machi_repos" && action_name == "show"
           current_page = "detail"

--- a/app/views/machi_repos/chats/index.html.erb
+++ b/app/views/machi_repos/chats/index.html.erb
@@ -1,8 +1,3 @@
-<%# turboのキャッシュが残っていると画面やスクロールがちらつく %>
-<% content_for :head do %>
-  <meta name="turbo-cache-control" content="no-cache">
-<% end %>
-
 <div data-controller="disable-scroll"></div>
 
 <div class="flex flex-col">
@@ -56,7 +51,8 @@
       </div>
     </div>
 
-    <%= form_with url: "#", method: :post, local: true, class:"fixed bottom-[68px] left-1/2 -translate-x-1/2 shadow-lg w-full max-w-[480px] md:bottom-[105px]" do |form| %>
+    <%# form_with url: "#", method: :post, local: true, class:"fixed bottom-[68px] left-1/2 -translate-x-1/2 shadow-lg w-full max-w-[480px] md:bottom-[105px]" do |form| %>
+    <%= form_with url: "#", method: :post, local: true, class:"absolute bottom-[-40px] shadow-lg w-full max-w-[480px]" do |form| %>
       <div data-machi-repos--chat-target="textareaForm">
         <div class="flex items-end p-1 bg-white">
           <div data-action="click->machi-repos--chat#toggleChatForm" class="flex-shrink-0 w-8 aspect-square text-green-600">

--- a/app/views/machi_repos/chats/index.html.erb
+++ b/app/views/machi_repos/chats/index.html.erb
@@ -12,8 +12,17 @@
     data-machi-repos--chat-textarea-resize-outlet=".textarea-resize"
   >
     <div
+      data-chat-scroll-target="scrollableIcon"
+      class="hidden absolute top-[8px] left-1/2 -translate-x-1/2 text-blue-300 z-1"
+    >
+      <div class="bounce w-8 aspect-square">
+        <%= render "shared/icons/arrow_upward_icon" %>
+      </div>
+    </div>
+    <%# chat-sectionのモバイル版の高さはtoggle_controller.jsで設定しているが、height設定をしないとスクロールができないため設定している %>
+    <div
       id="chat-section"
-      class="invisible px-2 h-[calc(100vh-440px)] overflow-y-auto transition-all duration-300 ease-in-out md:h-[calc(100vh-355px)]"
+      class="invisible px-2 h-[100px] overflow-y-auto transition-all duration-300 ease-in-out md:h-[calc(100vh-355px)]"
       data-chat-scroll-target="container"
       data-machi-repos--chat-target="container"
     >
@@ -25,7 +34,7 @@
       >
 
         <%# id="chat-last-page-marker"の後にturbo_frameでchatを追加(無限スクロール) %>
-        <div id="chat-last-page-marker" data-last-page="<%= @chats.last_page? %>" class="hidden"></div>
+        <div id="chat-last-page-marker" data-last-page="<%= @chats.empty? || @chats.last_page? %>" class="hidden"></div>
 
         <%# chatの初期表示 %>
         <%# 日付表示 %>

--- a/app/views/shared/icons/_arrow_upward_icon.html.erb
+++ b/app/views/shared/icons/_arrow_upward_icon.html.erb
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960" fill="currentColor">
+  <path d="M450-160v-526L202-438l-42-42 320-320 320 320-42 42-248-248v526h-60Z"/>
+</svg>


### PR DESCRIPTION
## 概要
- MVPリリース前にチャット画面の機能追加・修正を行った。
---
### 内容
- [x] チャットデータ読み込み数を15件に変更し、無限スクロールによるデータ取得開始スクロール位置を縮めた。
- [x] ウィンドウタブのタイトルを「Machi Vigil」に修正した。
- [x] モバイル版でチャット画面の表示領域が変更したときに、チャット表示領域の高さが変更されるように修正した。
- [x] 無限スクロール可能矢印を表示した。