### PR TITLE
fixed:まちレポ詳細：チャット画面のturboキャッシュを無効化した

### DIFF
--- a/app/views/machi_repos/chats/index.html.erb
+++ b/app/views/machi_repos/chats/index.html.erb
@@ -1,3 +1,7 @@
+<% content_for :head do %>
+  <meta name="turbo-cache-control" content="no-cache">
+<% end %>
+
 <div data-controller="disable-scroll"></div>
 
 <div class="flex flex-col">


### PR DESCRIPTION
## 概要
- まちレポのチャットに関して、Turboのキャッシュ機能を無効化した。一度キャッシュで画面が表示され操作していると、最新データが表示されたときにスクロールや閉じていたHTML要素が開いたりしてUXが悪くなるため。
---
### 内容
- [x] まちレポチャット「app/views/machi_repos/chats/index.html.erb」を修正した。