### PR TITLE
fixed:まちレポ編集画面でマイタウン表示ができないバグ修正

### DIFF
--- a/app/controllers/machi_repos_controller.rb
+++ b/app/controllers/machi_repos_controller.rb
@@ -1,4 +1,6 @@
 class MachiReposController < ApplicationController
+  before_action :set_mytown_location, only: %i[ new edit ]
+
   def index
     prepare_search_data
     respond_to do |format|
@@ -19,9 +21,7 @@ class MachiReposController < ApplicationController
 
   def new
     # Googleマップにマイタウンを表示するための情報取得
-    address = current_user.mytown_address
-    geocoding = Geocoder.search(address).first.coordinates
-    @machi_repo = MachiRepo.new(address: address, latitude: geocoding[0], longitude: geocoding[1])
+    @machi_repo = MachiRepo.new(address: @mytown_address, latitude: @mytown_latitude, longitude: @mytown_longitude)
   end
 
   def create
@@ -102,6 +102,14 @@ class MachiReposController < ApplicationController
     search_result = @search_form.search_machi_repos
     @machi_repos_count = search_result.length
     @machi_repos = search_result.page(params[:page])
+  end
+
+  # マイタウンの座標取得
+  def set_mytown_location
+    @mytown_address = current_user.mytown_address
+    geocoding = Geocoder.search(@mytown_address).first.coordinates
+    @mytown_latitude = geocoding[0]
+    @mytown_longitude = geocoding[1]
   end
 
   # DB登録時のストロングパラメータ取得

--- a/app/javascript/controllers/machi_repos/form_controller.js
+++ b/app/javascript/controllers/machi_repos/form_controller.js
@@ -17,19 +17,23 @@ export default class extends Controller {
   ];
 
   static values = {
-    apiKey: String,
-    mapId: String,
-    latitude: Number,
-    longitude: Number,
-    address: String,
     machiRepo: Object,
+    mytownLatitude: Number,
+    mytownLongitude: Number,
   };
 
   connect() {
-    // プロパティ
-    this.map = null; // マップ保持
-    this.mainMarker = null;  // メインマーカー保持
-    this.mytownCoordinates = null; // マイタウンの緯度・経度を保持
+    // マップ保持
+    this.map = null;
+    // メインマーカー保持
+    this.mainMarker = null;
+    // デフォルトの座標保持
+    this.defaultCoordinates = null;
+     // マイタウンの座標保持
+    this.mytownCoordinates = {
+      lat: this.mytownLatitudeValue,
+      lng: this.mytownLongitudeValue,
+    };
   }
 
   disconnect() {
@@ -64,7 +68,7 @@ export default class extends Controller {
 
     // マイタウン座標取得
     const mapCoordinates = this.map.getCenter();
-    this.mytownCoordinates = { lat: mapCoordinates.lat(), lng: mapCoordinates.lng() };
+    this.defaultCoordinates = { lat: mapCoordinates.lat(), lng: mapCoordinates.lng() };
 
     // エリア指定の円作成
     this.areaCircle = new google.maps.Circle({
@@ -73,7 +77,7 @@ export default class extends Controller {
       strokeWeight: 2,
       fillColor: "#00FF00",
       fillOpacity: 0.35,
-      center: this.mytownCoordinates,
+      center: this.defaultCoordinates,
       radius: Number(this.hotspotAreaRadiusSelectTarget.value),
     });
     // エリア指定orピンポイント指定

--- a/app/views/machi_repos/_form.html.erb
+++ b/app/views/machi_repos/_form.html.erb
@@ -48,6 +48,8 @@
   <div
     data-controller="machi-repos--form"
     data-machi-repos--form-machi-repo-value="<%= machi_repo.to_json %>"
+    data-machi-repos--form-mytown-latitude-value="<%= @mytown_latitude %>"
+    data-machi-repos--form-mytown-longitude-value="<%= @mytown_longitude %>"
     data-action="google-maps:google-maps-connected->machi-repos--form#initMap"
   >
     <!-- ホットスポット設定 -->
@@ -124,16 +126,18 @@
     </div>
 
     <!-- 住所 -->
-    <div class="mb-1">
-      <p>
-        <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#EA3323" class="inline-block">
-          <path d="M200-120v-680h343l19 86h238v370H544l-19-85H260v309h-60Z"/>
-        </svg>
-        <span data-machi-repos--form-target="displayAddress" class="text-xl font-bold">
-          <%= machi_repo.address %>
-        </span>
-        <%= form.hidden_field :address, data: { machi_repos__form_target: "address" } %>
-      </p>
+    <div class="my-4 text-center">
+      <div class="inline-block px-2 border-b-2 border-[#DF3737] text-2xl">
+        <div class="flex items-center">
+          <div class="inline-block w-6 aspect-square text-[#DF3737]">
+            <%= render "shared/icons/flag_full_icon" %>
+          </div>
+          <span data-machi-repos--form-target="displayAddress" class="text-xl font-bold">
+            <%= machi_repo.address %>
+          </span>
+          <%= form.hidden_field :address, data: { machi_repos__form_target: "address" } %>
+        </div>
+      </div>
     </div>
 
     <!-- Google Map -->


### PR DESCRIPTION
## 概要
- まちレポ修正画面でマイタウンをクリックした場合、マイタウンではなく登録されている座標が表示されてしまうバグを修正した。
---
### 内容
- [x] まちレポ編集画面のstimulusコントローラー「app/javascript/controllers/machi_repos/form_controller.js」を修正した。
- [x] まちレポ新規登録・編集用フォーム「app/views/machi_repos/_form.html.erb」を修正した。
- [x] まちレポコントローラー「app/controllers/machi_repos_controller.rb」を修正した。