### PR TITLE
fixed:まちレポチャットの無限スクロール方法修正、まちレポカードのリンクをturboに修正

### DIFF
--- a/app/controllers/machi_repos_controller.rb
+++ b/app/controllers/machi_repos_controller.rb
@@ -20,7 +20,7 @@ class MachiReposController < ApplicationController
   # "まち"のまちレポ無限スクロールデータ取得
   def load_more
     # まちレポ全体表示時のスナップショット取得
-    snapshot_time = Time.at(session[:records_snapshot_time].to_i)
+    snapshot_time = Time.at(session[:machi_repos_snapshot_time].to_i)
     cursor_updated_at = Time.at(params[:previous_last_updated].to_i)
     cursor_id = params[:previous_last_id].to_i
 
@@ -102,7 +102,7 @@ class MachiReposController < ApplicationController
   def prepare_search_data
     # 無限スクロール対策のため、UNIXタイムスタンプで保存
     snapshot_time = Time.current
-    session[:records_snapshot_time] = snapshot_time.to_i
+    session[:machi_repos_snapshot_time] = snapshot_time.to_i
 
     form_params = enrich_search_params_with_coordinates(search_params)
 

--- a/app/javascript/controllers/chat_scroll_controller.js
+++ b/app/javascript/controllers/chat_scroll_controller.js
@@ -14,7 +14,6 @@ export default class extends Controller {
 
   connect() {
     this.loading = false;
-    this.currentPage = 1;
 
     // 無限スクロールの要否判定
     const lastPageMarker = document.getElementById("chat-last-page-marker");
@@ -50,9 +49,14 @@ export default class extends Controller {
       return;
     }
     this.loading = true;
-    this.currentPage++;
 
-    const url = `/machi_repos/${this.machiRepoIdValue}/chats/load_more?page=${this.currentPage}`;
+    // URLのクエリパラメータ作成
+    const params = new URLSearchParams();
+    const previousLastData = document.getElementById("chats-previous-last-data");
+    params.append("previous_last_created", previousLastData.dataset.previousLastCreated);
+    params.append("previous_last_id", previousLastData.dataset.previousLastId);
+
+    const url = `/machi_repos/${this.machiRepoIdValue}/chats/load_more?${params.toString()}`;
     // 次のページ（上方向）を非同期で取得
     fetch(url, {
       headers: {

--- a/app/views/machi_repos/chats/index.html.erb
+++ b/app/views/machi_repos/chats/index.html.erb
@@ -39,7 +39,14 @@
       >
 
         <%# id="chat-last-page-marker"の後にturbo_frameでchatを追加(無限スクロール) %>
-        <div id="chat-last-page-marker" data-last-page="<%= @chats.empty? || @chats.last_page? %>" class="hidden"></div>
+        <div id="chat-last-page-marker" data-last-page="<%= @is_last_page %>" class="hidden"></div>
+        <%# 取得データの最後の更新日時とまちレポIDを保持 %>
+        <div
+          id="chats-previous-last-data"
+          data-previous-last-created="<%= @chats.last&.created_at&.to_i %>"
+          data-previous-last-id="<%= @chats.last&.id %>"
+          class="hidden"
+        ></div>
 
         <%# chatの初期表示 %>
         <%# 日付表示 %>

--- a/app/views/machi_repos/chats/load_more.turbo_stream.erb
+++ b/app/views/machi_repos/chats/load_more.turbo_stream.erb
@@ -1,8 +1,6 @@
 <%= turbo_stream.after "chat-last-page-marker" do %>
   <% previous_date = @new_prev_date %>
   <%= render "chat_date_block", date: previous_date %>
-  <% if @chats.last_page? %>
-  <% end %>
   <% @chats.reverse_each do |chat| %>
     <% chat_date = chat.created_at.to_date %>
     <% if previous_date != chat_date %>
@@ -19,5 +17,14 @@
 <% end %>
 
 <%= turbo_stream.replace "chat-last-page-marker" do %>
-  <div id="chat-last-page-marker" data-last-page="<%= @chats.last_page? %>" class="hidden"></div>
+  <div id="chat-last-page-marker" data-last-page="<%= @is_last_page %>" class="hidden"></div>
+<% end %>
+
+<%= turbo_stream.replace "chats-previous-last-data" do %>
+  <div
+    id="chats-previous-last-data"
+    data-previous-last-created="<%= @chats.last&.created_at&.to_i %>"
+    data-previous-last-id="<%= @chats.last&.id %>"
+    class="hidden"
+  ></div>
 <% end %>

--- a/app/views/shared/_machi_repo_card.html.erb
+++ b/app/views/shared/_machi_repo_card.html.erb
@@ -1,6 +1,6 @@
 <!-- まちレポカード -->
 <div class="w-full max-w-80 bg-white shadow-md">
-  <%= link_to machi_repo_path(machi_repo), data: { turbo: false }, class: "block" do %>
+  <%= link_to machi_repo_path(machi_repo), class: "block" do %>
     <% bg_class = case machi_repo.info_level
       when "share" then "bg-[#37DF6F]"
       when "warn" then "bg-[#F2CC0D]"


### PR DESCRIPTION
## 概要
- まちレポチャットの無限スクロール方法をスナップショットとcreated_at、idによるカーソル式に変更した。
---
### 内容
- [x] まちレポチャットの無限スクロール方法を修正した。
- [x] まちレポカードのa要素のturboをfalseにしていたが、turboで通信するように変更した(stimuluisコントローラーのdisconnectが行われていなかったため)。