### PR TITLE
fixed:ヘルプ表示の修正

### DIFF
--- a/app/javascript/controllers/accordion_controller.js
+++ b/app/javascript/controllers/accordion_controller.js
@@ -31,5 +31,13 @@ export default class extends Controller {
       openIcon.classList.remove("hidden");
       closeIcon.classList.add("hidden");
     }
+
+    item.addEventListener("transitionend", () => {
+      // itemのトップにスクロールする
+      item.scrollIntoView({
+        behavior: "smooth",
+        block: "start",
+      });
+    }, { once: true });
   }
 }

--- a/app/javascript/controllers/hamburger_menu_controller.js
+++ b/app/javascript/controllers/hamburger_menu_controller.js
@@ -7,11 +7,13 @@ export default class extends Controller {
     "cover",
   ];
 
-  connect() {
+  toggleMenu() {
+    this.menuTarget.classList.toggle("hidden");
+    this.coverTarget.classList.toggle("hidden");
   }
 
-  toggleMenu() {
-    this.menuTarget.classList.toggle('hidden');
-    this.coverTarget.classList.toggle('hidden');
+  disconnect() {
+    this.menuTarget.classList.add("hidden");
+    this.coverTarget.classList.add("hidden");
   }
 }

--- a/app/views/shared/_help_item.html.erb
+++ b/app/views/shared/_help_item.html.erb
@@ -12,7 +12,7 @@
     data-help-target="content"
     class="hidden fixed inset-0 bg-black/70 z-20"
   >
-    <div class="absolute top-1/2 -translate-y-1/2 left-1/2 -translate-x-1/2 rounded-xl py-4 w-full max-w-[900px] bg-white">
+    <div class="absolute top-1/2 -translate-y-1/2 left-1/2 -translate-x-1/2 rounded-xl py-4 w-full max-w-[900px] max-h-[80vh] overflow-y-scroll bg-white">
       <div class="flex justify-between mb-4 border-b border-gray-400 pb-2 px-2">
         <h3 class="header2"><%= title %></h3>
         <div


### PR DESCRIPTION
## 概要
- ヘルプ表示の修正を行った。
---
### 内容
- [x] ハンバーガーメニューからヘルプ画面へ遷移、その後まちれぽホームを表示すると、ハンバーガーメニューが一度おそらくキャッシュで表示されてしまうバグを修正した。ハンバーガーメニュー用stimulusのdisconnect時にhiddenをclass属性に追加することで、キャッシュでもhiddenにできている？
- [x] 各画面に表示するヘルプの最大高さを画面高さの8割に指定し、スクロールできるように修正した。
- [x] アコーディオンとして開いた要素のトップを画面のトップに表示させるするロール処理を追加した。