### PR TITLE
fixed:Google認証時に既に使用されているメールアドレスのアカウントを使用した時のエラーメッセージを修正

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -29,8 +29,10 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       flash[:notice] = "ログインしました"
       sign_in_and_redirect @user, event: :authentication
     else
+      flash[:alert] = [ "Googleログインに失敗しました" ]
+      flash[:alert] += @user.errors.full_messages if @user.errors.any?
       session["devise.google_data"] = request.env["omniauth.auth"].except(:extra)
-      redirect_to new_user_session_path, alert: "Googleログインに失敗しました"
+      redirect_to new_user_session_path
     end
   end
 


### PR DESCRIPTION
## 概要
- 既に通常のユーザー登録でメールアドレスが使用されている時に、Google認証時に表示させるエラーメッセージを修正した。
--- 内容
- [x] コールバックコントローラー「app/controllers/users/omniauth_callbacks_controller.rb」でUser登録失敗時のエラーメッセージをFlashを使って表示させるように修正した。