### PR TITLE
05 33 get chat image height

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,4 +12,14 @@ module ApplicationHelper
   def display_machi_repo_category_emoji(category)
     CATEGORY_EMOJIS[category] || "🎈"
   end
+
+  def aspect_height_style_for_chat_image(chat, width_em: 13, em_px: 16)
+    return "" unless chat.image? && chat.image_width.present? && chat.image_height.present?
+
+    width_px = width_em * em_px
+    aspect_ratio = chat.image_height.to_f / chat.image_width
+    height_px = (width_px * aspect_ratio).round
+
+    "height: #{height_px}px;"
+  end
 end

--- a/app/javascript/controllers/chat_scroll_controller.js
+++ b/app/javascript/controllers/chat_scroll_controller.js
@@ -23,12 +23,9 @@ export default class extends Controller {
       this.scrollableIconTarget.classList.remove("hidden");
     }
 
-    // 画像の表示が終了してから初期表示を行う
-    this.waitFormImagesLoaded().then(() => {
-      // 最初は一番下へスクロール
-      this.scrollToBottom();
-      this.containerTarget.classList.remove("invisible");
-    });
+    // 最初は一番下へスクロール
+    this.scrollToBottom();
+    this.containerTarget.classList.remove("invisible");
   }
 
   disconnect() {
@@ -37,7 +34,7 @@ export default class extends Controller {
 
   // 無限スクロール用トリガー
   onScroll = () => {
-    if (this.containerTarget.scrollTop < 300) {
+    if (this.containerTarget.scrollTop < 400) {
       // ページ最上部に近づいたとき
       this.loadPreviousPage();
     }
@@ -95,36 +92,6 @@ export default class extends Controller {
           this.scrollableIconTarget.classList.add("hidden");
         }
         this.loading = false;
-      });
-    });
-  }
-
-  // すべての画像が表示されるまで待つ
-  waitFormImagesLoaded() {
-    return new Promise(resolve => {
-      const images = this.element.querySelectorAll("img");
-      if (images.length === 0) {
-        resolve();
-        return;
-      }
-
-      let loadedCount = 0;
-      // stimulusコントローラー配下の画像読み込みをチェック
-      const checkLoaded = () => {
-        loadedCount++;
-        if (loadedCount === images.length) {
-          resolve();
-        }
-      };
-
-      images.forEach(img => {
-        if (img.complete && img.naturalHeight !== 0) {
-          // 既に読み込み済み
-          checkLoaded();
-        } else {
-          img.addEventListener("load", checkLoaded, { once: true });
-          img.addEventListener("error", checkLoaded, { once: true });
-        }
       });
     });
   }

--- a/app/javascript/controllers/machi_repos/chat_controller.js
+++ b/app/javascript/controllers/machi_repos/chat_controller.js
@@ -76,11 +76,8 @@ export default class extends Controller {
             requestAnimationFrame(() => {
               // 新着チャット処理
               if (this.isNearBottom()) {
-                // チャット画像の読み込み終了待ち
-                this.waitFormImageLoaded(chatId).then(() => {
-                  // bottom付近を見ていた場合、最下部へスクロール
-                  this.containerTarget.scrollTop = this.containerTarget.scrollHeight;
-                });
+                // bottom付近を見ていた場合、最下部へスクロール
+                this.containerTarget.scrollTop = this.containerTarget.scrollHeight;
               } else {
                 // Newアイコンを表示
                 this.newIconTarget.classList.remove("hidden");
@@ -238,29 +235,6 @@ export default class extends Controller {
       this.fileFieldFormTarget.classList.remove("hidden");
       this.textareaFormTarget.classList.add("hidden");
     }
-  }
-
-  // チャット画像が表示されるまで待機
-  waitFormImageLoaded(chatId) {
-    return new Promise(resolve => {
-      const image = this.chatAreaTarget.querySelector(`#${CSS.escape(`chat_${chatId}`)} img`);
-      if (!image) {
-        resolve();
-        return;
-      }
-
-      // すでに読み込み済みなら即解決
-      if (image.complete) {
-        resolve();
-        return;
-      }
-
-      // stimulusコントローラー配下の画像読み込みをチェック
-      const checkLoaded = () => resolve();
-
-      image.addEventListener("load", checkLoaded, { once: true });
-      image.addEventListener("error", checkLoaded, { once: true });
-    });
   }
 
   // 新着チャット表示

--- a/app/models/chat.rb
+++ b/app/models/chat.rb
@@ -18,6 +18,7 @@ class Chat < ApplicationRecord
     end
   end
 
+  # 画像サイズ用バリデーション
   def image_size_validation
     return unless image.present? && image.file.present?
 
@@ -26,6 +27,7 @@ class Chat < ApplicationRecord
     end
   end
 
+  # 画像の拡張子用バリデーション
   def image_extension_validation
     return unless image.present? && image.file.present?
 

--- a/app/uploaders/chat_image_uploader.rb
+++ b/app/uploaders/chat_image_uploader.rb
@@ -43,6 +43,9 @@ class ChatImageUploader < CarrierWave::Uploader::Base
   # アップロード時に画像の解像度を下げる
   process :optimize_image
 
+  # ここでサイズ取得（optimize_image のあとに呼ばれる）
+  process :store_dimensions
+
   def optimize_image
     manipulate! do |img|
       img.auto_orient        # 回転情報の自動補正（スマホ対応）
@@ -51,6 +54,16 @@ class ChatImageUploader < CarrierWave::Uploader::Base
       img.quality("80")      # 画質（70〜85が推奨）
       img
     end
+  end
+
+  def store_dimensions
+    if file && model
+      image = MiniMagick::Image.open(file.file)
+      model.image_width  = image.width
+      model.image_height = image.height
+    end
+  rescue => e
+    Rails.logger.warn "画像サイズの取得に失敗: Chat##{model.id || 'new'} - #{e.message}"
   end
 
   # Add an allowlist of extensions which are allowed to be uploaded.

--- a/app/views/shared/_chat_mine.html.erb
+++ b/app/views/shared/_chat_mine.html.erb
@@ -19,7 +19,7 @@
     <div class="chat-contents-wrapper">
       <% if chat&.image? %>
         <div class="chat-image-wrapper">
-          <%= image_tag(chat.image.url, loading: "lazy", class: "chat-image") %>
+          <%= image_tag(chat.image.url, loading: "lazy", class: "chat-image", style: aspect_height_style_for_chat_image(chat)) %>
         </div>
       <% elsif chat&.message.present? %>
         <div class="chat-message-wrapper">

--- a/app/views/shared/_chat_others.html.erb
+++ b/app/views/shared/_chat_others.html.erb
@@ -13,7 +13,7 @@
     </div>
     <% if chat&.image? %>
       <div class="chat-image-wrapper">
-        <%= image_tag(chat.image.url, loading: "lazy", class: "chat-image") %>
+        <%= image_tag(chat.image.url, loading: "lazy", class: "chat-image", style: aspect_height_style_for_chat_image(chat)) %>
       </div>
     <% elsif chat&.message.present? %>
       <div class="chat-message-wrapper">

--- a/db/migrate/20250701115817_add_image_dimensions_to_chats.rb
+++ b/db/migrate/20250701115817_add_image_dimensions_to_chats.rb
@@ -1,0 +1,6 @@
+class AddImageDimensionsToChats < ActiveRecord::Migration[8.0]
+  def change
+    add_column :chats, :image_width, :integer
+    add_column :chats, :image_height, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_26_021002) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_01_115817) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -22,6 +22,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_26_021002) do
     t.bigint "chatable_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "image_width"
+    t.integer "image_height"
     t.index ["chatable_type", "chatable_id"], name: "index_chats_on_chatable"
     t.index ["user_id"], name: "index_chats_on_user_id"
   end
@@ -39,12 +41,12 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_26_021002) do
   create_table "machi_repos", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.string "title", limit: 30, null: false
-    t.integer "info_level", null: false
-    t.integer "category", null: false
+    t.integer "info_level", default: 0, null: false
+    t.integer "category", default: 0, null: false
     t.text "description"
-    t.integer "hotspot_settings", null: false
+    t.integer "hotspot_settings", default: 0, null: false
     t.integer "hotspot_area_radius"
-    t.float "ratitude", null: false
+    t.float "latitude", null: false
     t.float "longitude", null: false
     t.string "image"
     t.integer "views_count", default: 0, null: false

--- a/lib/tasks/chats.rake
+++ b/lib/tasks/chats.rake
@@ -10,7 +10,7 @@ namespace :chats do
     skipped = 0
     failed  = 0
 
-    Chat.where.not(image: [nil, ""]).find_each do |chat|
+    Chat.where.not(image: [ nil, "" ]).find_each do |chat|
       if chat.image_width.present? && chat.image_height.present?
         skipped += 1
         next

--- a/lib/tasks/chats.rake
+++ b/lib/tasks/chats.rake
@@ -1,0 +1,49 @@
+namespace :chats do
+  desc "Update image dimensions (width, height) from S3 or local for existing Chat images"
+  task update_image_dimensions: :environment do
+    require "mini_magick"
+    require "open-uri"
+
+    puts "🖼️  画像サイズ更新を開始..."
+
+    updated = 0
+    skipped = 0
+    failed  = 0
+
+    Chat.where.not(image: [nil, ""]).find_each do |chat|
+      if chat.image_width.present? && chat.image_height.present?
+        skipped += 1
+        next
+      end
+
+      begin
+        if Rails.env.production?
+          # S3などURLから取得
+          URI.open(chat.image.url) do |file|
+            img = MiniMagick::Image.read(file)
+            chat.update_columns(image_width: img.width, image_height: img.height)
+            puts "✅ Chat ##{chat.id} updated: #{img.width}x#{img.height}"
+            updated += 1
+          end
+        else
+          # ローカルファイルから取得
+          local_path = File.join(Rails.root, "public", chat.image.url)
+          if File.exist?(local_path)
+            img = MiniMagick::Image.open(local_path)
+            chat.update_columns(image_width: img.width, image_height: img.height)
+            puts "✅ Chat ##{chat.id} updated: #{img.width}x#{img.height}"
+            updated += 1
+          else
+            puts "❌ Chat ##{chat.id} failed: local file not found"
+            failed += 1
+          end
+        end
+      rescue => e
+        puts "❌ Chat ##{chat.id} failed: #{e.message}"
+        failed += 1
+      end
+    end
+
+    puts "\n✅ 完了: 更新 #{updated} 件 / スキップ #{skipped} 件 / 失敗 #{failed} 件"
+  end
+end


### PR DESCRIPTION
## 概要
- チャットの初期表示時に画像の読み込みを待っていたが、オーバーヘッドが大きくなってしまっていた。そのため、画像の横幅と高さを保存しておき、アスペクト比を維持した画像の高さをimg要素に設定しておくことで、画像の読み込み前に画像の表示領域の高さを確保する様に修正した。おそらく、初期表示時のオーバーヘッドが減り、要素の最下部へのスクロールも違和感なくできるようになったはず。
---
### 内容
- [x] chatsテーブルにimage_widthとimage_heightを追加した。
- [x] チャットのアップローダークラスに画像アップロード時に、image_widthとimage_heightを保存する処理を追加した。
- [x] チャット用のpartialを修正した。
- [x] 既にアップロード済みのチャットの画像にimage_widthとimage_heigthを追加できるRakeタスクを追加した。