### PR TITLE
05 34 maximum allowed image upload size

### DIFF
--- a/app/javascript/controllers/flash_controller.js
+++ b/app/javascript/controllers/flash_controller.js
@@ -31,9 +31,7 @@ export default class extends Controller {
     const ul = document.createElement("ul");
     const li = document.createElement("li");
     li.classList.add("flash", "flash-alert");
-    li.addEventListener("click", e => {
-      this.close(e);
-    }, { once: true });
+    li.dataset.action = "click->flash#close";
     const text = document.createElement("span");
     text.classList.add("flash-text");
     text.textContent = message;
@@ -41,7 +39,7 @@ export default class extends Controller {
     svgWrap.classList.add("flash-close-icon", "flash-close-icon-alert");
 
     // 要素の組み立て
-    svgWrap.appendChild(this.svgElement);
+    svgWrap.appendChild(this.svgElement.cloneNode(true));
     li.appendChild(text);
     li.appendChild(svgWrap);
     ul.appendChild(li);

--- a/app/javascript/controllers/machi_repos/chat_controller.js
+++ b/app/javascript/controllers/machi_repos/chat_controller.js
@@ -160,6 +160,8 @@ export default class extends Controller {
     if (this.isSending) {
       return;
     }
+    // 表示中のフラッシュメッセージがあれば削除
+    this.callFlashClear();
     this.isSending = true;
     // 待機中表示
     this.spinnerTarget.classList.remove("hidden");
@@ -178,6 +180,8 @@ export default class extends Controller {
       } else {
         const errorData = await response.json();
         console.error("送信失敗", errorData.errors);
+        // フラッシュメッセージ表示
+        this.callFlashAlert(errorData.errors);
       }
     } catch (error) {
       console.error("ネットワークエラー", error);
@@ -294,5 +298,14 @@ export default class extends Controller {
   // Timeoutクリア
   cancelPress() {
     clearTimeout(this.timeoutId);
+  }
+
+  // flashコントローラーを利用してフラッシュメッセージをクリアする
+  callFlashClear() {
+    this.dispatch("flash-clear", { detail: { content: "" } });
+  }
+  // flashコントローラーを利用して、alertフラッシュメッセージを表示する
+  callFlashAlert(message) {
+    this.dispatch("flash-alert", { detail: { message } });
   }
 }

--- a/app/models/chat.rb
+++ b/app/models/chat.rb
@@ -5,35 +5,4 @@ class Chat < ApplicationRecord
   mount_uploader :image, ChatImageUploader
 
   validates :message, length: { maximum: 500 }
-  validate  :message_or_image_present
-  validate  :image_size_validation
-  validate  :image_extension_validation
-
-  private
-
-  # messageかimageのどちらかは必須
-  def message_or_image_present
-    if message.blank? && image.blank?
-      errors.add(:base, "メッセージまたは画像のいずれかを入力してください")
-    end
-  end
-
-  # 画像サイズ用バリデーション
-  def image_size_validation
-    return unless image.present? && image.file.present?
-
-    if image.file.size > 2.megabytes
-      errors.add(:image, "は2MB以下のファイルをアップロードしてください")
-    end
-  end
-
-  # 画像の拡張子用バリデーション
-  def image_extension_validation
-    return unless image.present? && image.file.present?
-
-    extension = image.file.extension&.downcase
-    unless %w[jpg jpeg gif png].include?(extension)
-      errors.add(:image, "はJPG, JPEG, PNG, GIF形式のみアップロードできます")
-    end
-  end
 end

--- a/app/models/machi_repo.rb
+++ b/app/models/machi_repo.rb
@@ -40,23 +40,9 @@ class MachiRepo < ApplicationRecord
   validates :latitude, presence: true, numericality: { greater_than_or_equal_to: -90, less_than_or_equal_to: 90 }
   validates :longitude, presence: true, numericality: { greater_than_or_equal_to: -180, less_than_or_equal_to: 180 }
   validates :hotspot_area_radius, numericality: { only_integer: true, greater_than: 0 }, allow_nil: true
-  validate  :image_size_validation
-  validate  :image_extension_validation
   validate  :tag_names_validation
 
   private
-
-  def image_size_validation
-    if image.present? && image.file.size > 2.megabytes
-      errors.add(:image, "は2MB以下のファイルをアップロードしてください")
-    end
-  end
-
-  def image_extension_validation
-    if image.present? && !%w[jpg jpeg gif png].include?(image.file.extension.downcase)
-      errors.add(:image, "はJPG, JPEG, PNG, GIF形式のみアップロードできます")
-    end
-  end
 
   def tag_names_validation
     return unless tag_names.present?

--- a/app/uploaders/chat_image_uploader.rb
+++ b/app/uploaders/chat_image_uploader.rb
@@ -75,7 +75,7 @@ class ChatImageUploader < CarrierWave::Uploader::Base
 
   # アップロード可能なファイルサイズの制限
   def size_range
-    1.byte..5.megabytes
+    1.byte..10.megabytes
   end
 
   # Override the filename of the uploaded files:

--- a/app/uploaders/machi_repo_image_uploader.rb
+++ b/app/uploaders/machi_repo_image_uploader.rb
@@ -63,7 +63,7 @@ class MachiRepoImageUploader < CarrierWave::Uploader::Base
 
   # アップロード可能なファイルサイズの制限
   def size_range
-    1.byte..5.megabytes
+    1.byte..10.megabytes
   end
 
   # Override the filename of the uploaded files:

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,7 +35,9 @@
     <div
       id="flash_messages"
       data-controller="flash"
-      data-action="machi-repos--form:flash-alert@window->flash#showAlertMessage machi-repos--form:flash-clear@window->flash#clear"
+      data-action="machi-repos--form:flash-alert@window->flash#showAlertMessage machi-repos--form:flash-clear@window->flash#clear
+      machi-repos--chat:flash-alert@window->flash#showAlertMessage
+      machi-repos--chat:flash-clear@window->flash#clear"
     >
       <%= render "shared/flash_messages" %>
     </div>

--- a/config/locales/activerecords/ja.yml
+++ b/config/locales/activerecords/ja.yml
@@ -23,6 +23,8 @@ ja:
         longitude: 経度
         image: 画像
         views_count: 視聴数
+      chat:
+        image: 画像
   enums:
     machi_repo:
       category:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -110,6 +110,12 @@ ja:
       too_long: は%{count}文字以内で入力してください
       too_short: は%{count}文字以上で入力してください
       wrong_length: は%{count}文字で入力してください
+      max_size_error: サイズが大きすぎます（最大%{max_size}）
+      min_size_error: サイズが小さすぎます（最小%{min_size}）
+      extension_allowlist_error: に許可されていないファイル形式が設定されています（許可：%{allowed_types}）
+      content_type_allowlist_error: "に許可されていないMIMEタイプが設定されています（許可：%{allowed_types}）"
+      too_many_files: "のファイル数が多すぎます"
+      integrity_error: "ファイルに問題があります"
     template:
       body: 次の項目を確認してください
       header: "%{model}に%{count}個のエラーが発生しました"


### PR DESCRIPTION
## 概要
- 画像アップロード時にスマホで撮った画像がアップロードできなかった。アップローダークラスの設定が2MBになっていたが、10MBまで引き上げた。アップローダークラス内でリサイズ処理を行っており、10MBのものでも実際に保存される画像は1MBにも満たないようになっている。
---
### 内容
- [x] まちレポ作成・編集の画像サイズ上限をアップローダークラス内で10MBに引き上げた。
- [x] まちレポチャットの画像サイズ上限をアップローダークラス内で10MBに引き上げた。
- [x] チャット投稿時のエラーをフラッシュメッセージで表示できるように修正した。 