### PR TITLE
fixed:Chatのimage_width、image_heightをアップローダークラスで設定するように再修正

### DIFF
--- a/app/models/chat.rb
+++ b/app/models/chat.rb
@@ -2,20 +2,7 @@ class Chat < ApplicationRecord
   belongs_to :user
   belongs_to :chatable, polymorphic: true
 
-  before_save :set_image_dimensions, if: -> { image.present? && image_changed? }
-
   mount_uploader :image, ChatImageUploader
 
   validates :message, length: { maximum: 500 }
-
-  private
-
-  # 画像の横幅と高さを設定する
-  def set_image_dimensions
-    return unless image&.file&.exists?
-
-    img = MiniMagick::Image.open(image.file.file)
-    self.image_width = img.width
-    self.image_height = img.height
-  end
 end

--- a/app/uploaders/chat_image_uploader.rb
+++ b/app/uploaders/chat_image_uploader.rb
@@ -50,6 +50,13 @@ class ChatImageUploader < CarrierWave::Uploader::Base
       img.strip              # EXIFなど不要なメタデータを除去
       img.resize "1280x720>" # スマホ向けに設定
       img.quality("80")      # 画質（70〜85が推奨）
+
+      # サイズ取得（img は MiniMagick::Image）
+      if model
+        model.image_width  = img.width
+        model.image_height = img.height
+      end
+
       img
     end
   end


### PR DESCRIPTION
## 概要
- Chatモデルでimage_widthとimage_heightを設定するように修正したが、本番環境で上手くいかなかった。そのため、アップローダークラスで設定するように戻した。