### PR TITLE
add:ユーザーページ追加

### DIFF
--- a/app/controllers/machi_repos_controller.rb
+++ b/app/controllers/machi_repos_controller.rb
@@ -113,7 +113,8 @@ class MachiReposController < ApplicationController
 
   # マイまちレポ
   def my_machi_repos
-    total_records = current_user.machi_repos
+    @user = User.find(params[:user_id])
+    total_records = @user.machi_repos
     load_init_data("machi_repos", total_records, MACHI_REPO_PER_PAGE)
     @machi_repos = @records
     @machi_repos_count = @total_records_count
@@ -121,7 +122,8 @@ class MachiReposController < ApplicationController
 
   # マイまちレポの無限スクロール
   def load_more_my_machi_repos
-    total_records = current_user.machi_repos
+    user = User.find(params[:user_id])
+    total_records = user.machi_repos
     load_more_data("machi_repos", total_records, MACHI_REPO_PER_PAGE)
     respond_to do |format|
       format.turbo_stream

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,8 +1,10 @@
 class ProfilesController < ApplicationController
   skip_before_action :ensure_profile_created, only: %i[ new create ]
-  before_action :set_profile, only: %i[ show edit ]
 
-  def show; end
+  def show
+    @profile = Profile.find(params[:id])
+    @user = @profile.user
+  end
 
   def new
     @profile = Profile.new
@@ -19,7 +21,9 @@ class ProfilesController < ApplicationController
     end
   end
 
-  def edit; end
+  def edit
+    @profile = current_user.profile
+  end
 
   def update
     @profile = current_user.profile
@@ -32,10 +36,6 @@ class ProfilesController < ApplicationController
   end
 
   private
-
-  def set_profile
-    @profile = current_user.profile
-  end
 
   # エラーメッセージを追加する
   def append_errors_to_flash(record, action_name)

--- a/app/javascript/controllers/infinite_scroll_controller.js
+++ b/app/javascript/controllers/infinite_scroll_controller.js
@@ -13,6 +13,7 @@ export default class extends Controller {
   static values = {
     controllerName: String,
     actionName: String,
+    userId: Number,
   };
 
   connect() {
@@ -53,6 +54,10 @@ export default class extends Controller {
     params.append("previous_last_updated", this.previousLastUpdatedTarget.value);
     // 最終データのID
     params.append("previous_last_id", this.previousLastIdTarget.value);
+    // ユーザーID
+    if (this.userIdValue) {
+      params.append("user_id", this.userIdValue);
+    }
 
     const url = `/${controller}/${action}?${params.toString()}`;
     // 次のページ（下方向）を非同期で取得

--- a/app/views/machi_repos/bookmarks.html.erb
+++ b/app/views/machi_repos/bookmarks.html.erb
@@ -4,6 +4,7 @@
   <%= render "shared/infinite_scroll_item",
     controller: "machi_repos",
     action: "load_more_bookmarks",
+    user_id: 0,
     title: "まちレポブックマーク一覧",
     objects_count: @machi_repos_count,
     snapshot_time: @snapshot_time,

--- a/app/views/machi_repos/my_machi_repos.html.erb
+++ b/app/views/machi_repos/my_machi_repos.html.erb
@@ -1,9 +1,14 @@
-<%= render "shared/mypage_info" %>
+<% if current_user == @user %>
+  <%= render "shared/mypage_info" %>
+<% else %>
+  <%= render "shared/userpage_info", user: @user %>
+<% end %>
 
 <section class="mx-auto pt-4 pb-8 max-w-120 lg:max-w-175 xl:max-w-250">
   <%= render "shared/infinite_scroll_item",
     controller: "machi_repos",
     action: "load_more_my_machi_repos",
+    user_id: @user.id,
     title: "マイまちレポ一覧",
     objects_count: @machi_repos_count,
     snapshot_time: @snapshot_time,

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,15 +1,22 @@
-<%= render "shared/mypage_info" %>
+<% if current_user == @user %>
+  <%= render "shared/mypage_info" %>
+<% else %>
+  <%= render "shared/userpage_info", user: @user %>
+<% end %>
+
 
 <section class="mx-auto pt-4 pb-8 max-w-120">
   <div class="flex justify-end gap-2 mb-4 pr-2 w-full">
-    <%# 編集 %>
-    <%= link_to edit_profile_path(@profile), class: "inline-block border-2 rounded px-2 bg-green-100 text-green-700 shadow", id: "machi-repo-edit" do %>
-      <div class="flex flex-col justify-center items-center">
-        <div class="w-8 aspect-square">
-          <%= render "shared/icons/edit_note_icon" %>
+    <% if current_user == @user %>
+      <%# 編集 %>
+      <%= link_to edit_profile_path(@profile), class: "inline-block border-2 rounded px-2 bg-green-100 text-green-700 shadow", id: "machi-repo-edit" do %>
+        <div class="flex flex-col justify-center items-center">
+          <div class="w-8 aspect-square">
+            <%= render "shared/icons/edit_note_icon" %>
+          </div>
+          <span class="text-sm">編集</span>
         </div>
-        <span class="text-sm">編集</span>
-      </div>
+      <% end %>
     <% end %>
   </div>
   <div class="">

--- a/app/views/shared/_infinite_scroll_item.html.erb
+++ b/app/views/shared/_infinite_scroll_item.html.erb
@@ -1,6 +1,7 @@
 <div data-controller="infinite-scroll"
   data-infinite-scroll-controller-name-value="<%= controller %>"
   data-infinite-scroll-action-name-value="<%= action %>"
+  data-infinite-scroll-user-id-value="<%= user_id %>"
 >
   <%# タイトル表示 %>
   <% if title.present? %>

--- a/app/views/shared/_machi_repo_card.html.erb
+++ b/app/views/shared/_machi_repo_card.html.erb
@@ -37,7 +37,11 @@ end %>
           <%= render "shared/icons/face_icon" %>
         </span>
         <span class="ml-1 truncate overflow-hidden whitespace-nowrap">
-          <%= machi_repo.user.profile.nickname %>
+          <% if current_user == machi_repo.user %>
+            <%= machi_repo.user.profile.nickname %>
+          <% else %>
+            <%= link_to machi_repo.user.profile.nickname, profile_path(machi_repo.user.profile), class: "link underline" %>
+          <% end %>
         </span>
         <!-- ブックマーク -->
         <% if current_user != machi_repo.user %>

--- a/app/views/shared/_userpage_info.html.erb
+++ b/app/views/shared/_userpage_info.html.erb
@@ -1,10 +1,10 @@
-<% content_for :title, "マイページ" %>
+<% content_for :title, "ユーザー詳細" %>
 
 <div class="border-b-2 border-gray-400 text-center">
   <h2 class="mb-6">
-    <span class="header1">マイページ</span>
+    <span class="header1"><%= user.profile.nickname %></span>
     <p>
-      登録したプロフィールを確認できます
+      ユーザーのプロフィールを確認できます
     </p>
   </h2>
 
@@ -14,14 +14,12 @@
         current_page = "profile"
       elsif controller_name == "machi_repos" && action_name == "my_machi_repos"
         current_page = "my_machi_repos"
-      elsif controller_name == "machi_repos" && action_name == "bookmarks"
-        current_page = "bookmark"
       else
         current_page = ""
       end %>
       <!-- プロフィール -->
       <li>
-        <%= link_to profile_path(current_user.profile), class: "icon-circle-wrapper #{"icon-circle-wrapper-current" if current_page == "profile"}", id: "profile-link" do %>
+        <%= link_to profile_path(user.profile), class: "icon-circle-wrapper #{"icon-circle-wrapper-current" if current_page == "profile"}", id: "profile-link" do %>
           <div class="icon-circle <%= "icon-circle-current" if current_page == "profile" %>">
             <div class="w-8 aspect-square">
               <%= render "shared/icons/person_icon" %>
@@ -32,35 +30,13 @@
       </li>
       <!-- マイまちレポ -->
       <li>
-        <%= link_to my_machi_repos_machi_repos_path(user_id: current_user.id), class: "icon-circle-wrapper #{"icon-circle-wrapper-current" if current_page == "my_machi_repos"}", id: "my-machi-repo-link" do %>
+        <%= link_to my_machi_repos_machi_repos_path(user_id: user.id), class: "icon-circle-wrapper #{"icon-circle-wrapper-current" if current_page == "my_machi_repos"}", id: "my-machi-repo-link" do %>
           <div class="icon-circle <%= "icon-circle-current" if current_page == "my_machi_repos" %>">
             <div class="w-8 aspect-square">
               <%= render "shared/icons/home_work_icon" %>
             </div>
           </div>
           <span class="icon-circle-text text-[13px]">マイまちレポ</span>
-        <% end %>
-      </li>
-      <!-- ブックマーク -->
-      <li>
-        <%= link_to bookmarks_machi_repos_path, class: "icon-circle-wrapper #{"icon-circle-wrapper-current" if current_page == "bookmark"}", id: "bookmark-link" do %>
-          <div class="icon-circle <%= "icon-circle-current" if current_page == "bookmark" %>">
-            <div class="w-8 aspect-square">
-              <%= render "shared/icons/star_icon" %>
-            </div>
-          </div>
-          <span class="icon-circle-text text-[13px]">ブックマーク</span>
-        <% end %>
-      </li>
-      <!-- フォロー -->
-      <li>
-        <%= link_to "#", class: "icon-circle-wrapper #{"icon-circle-wrapper-current" if current_page == "follow"}", id: "follow-link" do %>
-          <div class="icon-circle <%= "icon-circle-current" if current_page == "follow" %>">
-            <div class="w-8 aspect-square">
-              <%= render "shared/icons/owl_icon" %>
-            </div>
-          </div>
-          <span class="icon-circle-text text-[13px]">フォロー</span>
         <% end %>
       </li>
       <!-- コミュニティ -->


### PR DESCRIPTION
## 概要
- マイページで作成したものをベースに、ユーザーページを作成した。
---
### 内容
- [x] ユーザーページ用のナビゲーションを追加した。
- [x] プロフィール詳細、マイまちレポ画面にuser_idの概念を追加した。
- [x] まちレポカードからユーザー詳細ページに飛べるようにした。