### PR TITLE
fixed:ユーザープロフィールのマイタウンがログイン中のユーザーのマイタウンになっていたバグを修正

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -3,7 +3,6 @@ class ProfilesController < ApplicationController
 
   def show
     @profile = Profile.find(params[:id])
-    @user = @profile.user
   end
 
   def new

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,13 +1,13 @@
-<% if current_user == @user %>
+<% if current_user == @profile.user %>
   <%= render "shared/mypage_info" %>
 <% else %>
-  <%= render "shared/userpage_info", user: @user %>
+  <%= render "shared/userpage_info", user: @profile.user %>
 <% end %>
 
 
 <section class="mx-auto pt-4 pb-8 max-w-120">
   <div class="flex justify-end gap-2 mb-4 pr-2 w-full">
-    <% if current_user == @user %>
+    <% if current_user == @profile.user %>
       <%# 編集 %>
       <%= link_to edit_profile_path(@profile), class: "inline-block border-2 rounded px-2 bg-green-100 text-green-700 shadow", id: "machi-repo-edit" do %>
         <div class="flex flex-col justify-center items-center">
@@ -56,7 +56,7 @@
         <span class="header2">マイタウン</span>
       </h3>
       <div class="ml-8 text-xl font-bold">
-        <%= current_user.mytown_address %>
+        <%= @profile.user.mytown_address %>
       </div>
     </div>
     <!-- 自己紹介 -->


### PR DESCRIPTION
## 概要
- ユーザー詳細のプロフィールのマイタウンが、ログイン中のユーザーのものになって知っているバグを修正した。