### PR TITLE
fixed:参加希望取り消し処理を修正

### DIFF
--- a/app/controllers/community_memberships_controller.rb
+++ b/app/controllers/community_memberships_controller.rb
@@ -9,6 +9,7 @@ class CommunityMembershipsController < ApplicationController
     end
 
     membership = CommunityMembership.find_or_initialize_by(user: current_user, community: @community)
+
     @status = "requested"
     membership.status = @status
     membership.role = "general"
@@ -53,6 +54,12 @@ class CommunityMembershipsController < ApplicationController
   end
 
   def cancel
+    # 参加中のユーザーは拒否
+    if current_user.approved_in?(@community)
+      redirect_to community_path(@community), alert: "既にこのコミュニティに参加しています"
+      return
+    end
+
     @membership = CommunityMembership.find_by(user: current_user, community: @community)
     @previous_status = @membership&.status
     if @membership.update(status: :cancelled, role: :general)


### PR DESCRIPTION
## 概要
- ユーザーがコミュニティへの参加希望を出した後、参加を許可する。その後ユーザー側が画面遷移せずに参加希望を取り消すことができていたため修正した。