### PR TITLE
fixed:コミュニティスカウトの検索時にスカウトボタンが表示されないバグ修正

### DIFF
--- a/app/views/communities/scout_search.turbo_stream.erb
+++ b/app/views/communities/scout_search.turbo_stream.erb
@@ -1,6 +1,6 @@
 <%= turbo_stream.update "candidate-user-cards" do %>
   <!-- ユーザーカード -->
   <% @scout_candidates.each do |user| %>
-    <%= render "shared/user_card", user: user, option: nil, buttons: nil %>
+    <%= render "shared/user_card", user: user, option: render("community_memberships/buttons/invite_button", community: @community, user: user), buttons: nil %>
   <% end %>
 <% end %>


### PR DESCRIPTION
## 概要
- コミュニティのスカウト画面でユーザー検索を行った時にスカウト用のアイコンが表示されていなかったため、修正した。