### PR TITLE
05 62 community chat 2

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -485,7 +485,7 @@ input:-webkit-autofill{
 /* チャット */
 .chat {
   display: flex;
-  gap: 0.25rem;
+  gap: 0.375rem;
   justify-content: end;
   position: relative;
   margin-bottom: 1.5rem;
@@ -503,11 +503,8 @@ input:-webkit-autofill{
   flex-direction: column;
   justify-content: end;
   color: #4b5563;
-}
-/* 投稿時間 */
-.chat-time {
-  margin-bottom: 0.25rem;
-  font-size: 0.875rem;
+  font-size: 0.75rem;
+  text-align: right;
 }
 /* メッセージ領域 */
 .chat-message-wrapper {

--- a/app/controllers/communities/chats_controller.rb
+++ b/app/controllers/communities/chats_controller.rb
@@ -105,6 +105,8 @@ class Communities::ChatsController < ApplicationController
 
     @chat.destroy!
 
+    @other_chats_on_same_day_exist = @community.chats.where(created_at: @chat.created_at.to_date.all_day).where.not(id: @chat.id).exists?
+
     # Action Cableで他のユーザーにも通知
     ActionCable.server.broadcast "community_chat_#{@community.id}", {
       type: "destroy",

--- a/app/controllers/community_memberships_controller.rb
+++ b/app/controllers/community_memberships_controller.rb
@@ -206,6 +206,8 @@ class CommunityMembershipsController < ApplicationController
     end
 
     if @membership.update(status: :withdrawn, role: :general)
+      # チャット既読を削除
+      CommunityChatRead.where(user_id: current_user.id, community_id: community.id).destroy_all
       redirect_to community_path(community), notice: "退会しました"
     else
       redirect_to community_path(community), alert: "退会できませんでした"
@@ -231,6 +233,8 @@ class CommunityMembershipsController < ApplicationController
     user_name = user.profile.nickname
     # 強制退会させられるのは通常メンバーのみ
     if @membership.general? && @membership.update(status: :kicked, role: :general)
+      # チャット既読を削除
+      CommunityChatRead.where(user_id: user.id, community_id: community.id).destroy_all
       flash.now[:notice] = "\"#{user_name}\"さんに退会してもらいました"
     else
       flash.now[:alert] = "\"#{user_name}\"さんを退会させられませんでした"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -24,4 +24,15 @@ module ApplicationHelper
 
     "height: #{height_px}px;"
   end
+
+  # チャットの既読数表示
+  def format_read_count(count)
+    if count == 1
+      "既読"
+    elsif count >= 2
+      "既読 #{count}"
+    else
+      ""
+    end
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -35,4 +35,13 @@ module ApplicationHelper
       ""
     end
   end
+
+  # コミュニティに参加しているユーザー名取得(チャット用)
+  def display_community_user_name(user, approved_user_ids)
+    if approved_user_ids.include?(user.id)
+      user.profile&.nickname || "(unknown)"
+    else
+      "(unknown)"
+    end
+  end
 end

--- a/app/javascript/controllers/chat_controller.js
+++ b/app/javascript/controllers/chat_controller.js
@@ -81,6 +81,8 @@ export default class extends Controller {
     // 既読情報更新
     this.markLatestAsRead();
 
+    this.textareaTarget.focus();
+
     // イベントリスナー設定
     // 画面リサイズ時のチャット画面の高さ調整
     window.addEventListener("resize", this.resizeChatAreaHeight);
@@ -342,6 +344,7 @@ export default class extends Controller {
       resetTarget: this.textareaTarget,
     });
 
+    this.textareaTarget.focus();
     this.textareaResizeOutlet?.resize();
   }
 

--- a/app/javascript/controllers/chat_controller.js
+++ b/app/javascript/controllers/chat_controller.js
@@ -17,6 +17,7 @@ export default class extends Controller {
     "fileField",
     "newIcon",
     "spinner",
+    "lastReadChatId",
     "lastPageMarker",
     "previousLastCreated",
     "previousLastId",
@@ -27,6 +28,7 @@ export default class extends Controller {
     controllerName: String,
     channelName: String,
     objectId: Number,
+    lastChatId: Number,
   };
 
   static outlets = [
@@ -75,6 +77,10 @@ export default class extends Controller {
     // チャネルの購読開始
     this.subscribeChannel();
 
+    // 既読情報更新
+    this.markLatestAsRead();
+
+    // イベントリスナー設定
     // 画面リサイズ時のチャット画面の高さ調整
     window.addEventListener("resize", this.resizeChatAreaHeight);
     // Newアイコンを非表示にする
@@ -92,6 +98,7 @@ export default class extends Controller {
   }
 
   disconnect() {
+    // イベントリスナ－解放
     window.removeEventListener("resize", this.resizeChatAreaHeight);
 
     this.containerTarget.removeEventListener("scroll", this.infiniteScroll);
@@ -187,6 +194,17 @@ export default class extends Controller {
     }
 
     this.subscription = null;
+  }
+
+  markLatestAsRead() {
+    fetch(`/${this.controllerNameValue}/${this.objectIdValue}/chats/mark_as_read`, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        "X-CSRF-Token": document.querySelector("meta[name='csrf-token']").content
+      },
+      body: JSON.stringify({ last_read_chat_id: this.lastReadChatIdTarget.value })
+    });
   }
 
   // 部分テンプレート取得によるチャット表示

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -7,6 +7,9 @@ class Community < ApplicationRecord
   has_many :requested_memberships, -> { where(status: :requested) }, class_name: "CommunityMembership"
   # statusがrequestedのユーザーを取得する
   has_many :requested_users, through: :requested_memberships, source: :user
+  # コミュニティチャット既読数
+  has_many :community_chat_reads, dependent: :destroy
+  has_many :reading_users, through: :community_chat_reads, source: :user
 
   validates :name, presence: true, length: { maximum: 20 }, uniqueness: {
     scope: [ :prefecture_id, :municipality_id ],

--- a/app/models/community_chat_read.rb
+++ b/app/models/community_chat_read.rb
@@ -1,4 +1,7 @@
 class CommunityChatRead < ApplicationRecord
   belongs_to :user
   belongs_to :community
+
+  validates :last_read_chat_id, numericality: { only_integer: true }
+  validates :user_id, uniqueness: { scope: :community_id }  # 同じユーザーが同じコミュニティで複数行を持たないように
 end

--- a/app/models/community_chat_read.rb
+++ b/app/models/community_chat_read.rb
@@ -1,0 +1,4 @@
+class CommunityChatRead < ApplicationRecord
+  belongs_to :user
+  belongs_to :community
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,6 +21,9 @@ class User < ApplicationRecord
   has_many :followers, through: :passive_follows, source: :follower
   has_many :community_memberships, dependent: :destroy
   has_many :communities, through: :community_memberships
+  # コミュニティチャット既読数
+  has_many :community_chat_reads, dependent: :destroy
+  has_many :read_communities, through: :community_chat_reads, source: :community
 
   attr_accessor :agreement
   validates :agreement, acceptance: { accept: "1", message: "に同意してください" }

--- a/app/views/communities/chats/destroy.turbo_stream.erb
+++ b/app/views/communities/chats/destroy.turbo_stream.erb
@@ -1,1 +1,5 @@
 <%= turbo_stream.remove @chat %>
+
+<% unless @other_chats_on_same_day_exist %>
+  <%= turbo_stream.remove "chat-date-#{@chat.created_at&.to_date}" %>
+<% end %>

--- a/app/views/communities/chats/index.html.erb
+++ b/app/views/communities/chats/index.html.erb
@@ -91,7 +91,7 @@
             <% if current_user == chat.user %>
               <%= render "shared/chat_mine", chat: chat, chat_color_class_name: "default", read_counts_hash: @read_counts_hash, remove_button: render("communities/chats/chat_remove_button", community: @community, chat: chat) %>
             <% else %>
-              <%= render "shared/chat_others", nickname: chat.user.profile.nickname, chat: chat %>
+              <%= render "shared/chat_others", nickname: display_community_user_name(chat.user, @approved_user_ids), chat: chat %>
             <% end %>
           <% end %>
         </div>

--- a/app/views/communities/chats/index.html.erb
+++ b/app/views/communities/chats/index.html.erb
@@ -47,6 +47,12 @@
         id="chat-area"
         data-chat-target="chatArea"
       >
+        <%# 既読数管理用ID %>
+        <input type="hidden"
+          id="last-read-chat-id"
+          value="<%= @chats.first&.id || 0 %>"
+          data-chat-target="lastReadChatId"
+        >
         <%# 最終ページ判定 %>
         <input type="hidden"
           id="last-page-marker"
@@ -82,7 +88,7 @@
             <% previous_date = chat_date %>
 
             <% if current_user == chat.user %>
-              <%= render "shared/chat_mine", chat: chat, chat_color_class_name: "default", remove_button: render("communities/chats/chat_remove_button", community: @community, chat: chat) %>
+              <%= render "shared/chat_mine", chat: chat, chat_color_class_name: "default", read_counts_hash: @read_counts_hash, remove_button: render("communities/chats/chat_remove_button", community: @community, chat: chat) %>
             <% else %>
               <%= render "shared/chat_others", nickname: chat.user.profile.nickname, chat: chat %>
             <% end %>

--- a/app/views/communities/chats/index.html.erb
+++ b/app/views/communities/chats/index.html.erb
@@ -8,6 +8,7 @@
   data-controller="chat"
   data-chat-controller-name-value="communities"
   data-chat-channel-name-value="CommunityChatChannel"
+  data-chat-user-id-value="<%= current_user.id %>"
   data-chat-object-id-value="<%= @community.id %>"
   data-chat-textarea-resize-outlet=".textarea-resize"
 >

--- a/app/views/communities/chats/load_more.turbo_stream.erb
+++ b/app/views/communities/chats/load_more.turbo_stream.erb
@@ -13,7 +13,7 @@
     <% if current_user == chat.user %>
       <%= render "shared/chat_mine", chat: chat, chat_color_class_name: "default", read_counts_hash: @read_counts_hash, remove_button: render("communities/chats/chat_remove_button", community: @community, chat: chat) %>
     <% else %>
-      <%= render "shared/chat_others", nickname: chat.user.profile.nickname, chat: chat %>
+      <%= render "shared/chat_others", nickname: display_community_user_name(chat.user, @approved_user_ids), chat: chat %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/communities/chats/load_more.turbo_stream.erb
+++ b/app/views/communities/chats/load_more.turbo_stream.erb
@@ -11,7 +11,7 @@
 
     <%# レコード表示 %>
     <% if current_user == chat.user %>
-      <%= render "shared/chat_mine", chat: chat, chat_color_class_name: "default", remove_button: render("communities/chats/chat_remove_button", community: @community, chat: chat) %>
+      <%= render "shared/chat_mine", chat: chat, chat_color_class_name: "default", read_counts_hash: @read_counts_hash, remove_button: render("communities/chats/chat_remove_button", community: @community, chat: chat) %>
     <% else %>
       <%= render "shared/chat_others", nickname: chat.user.profile.nickname, chat: chat %>
     <% end %>

--- a/app/views/communities/chats/render_chat.turbo_stream.erb
+++ b/app/views/communities/chats/render_chat.turbo_stream.erb
@@ -3,7 +3,7 @@
     <%= render "shared/chat_date_block", date: @chat.created_at.to_date %>
   <% end %>
   <% if current_user == @user %>
-    <%= render "shared/chat_mine", chat: @chat, chat_color_class_name: "default", read_counts_hash: nil, remove_button: render("communities/chats/chat_remove_button", community: @community, chat: @chat) %>
+    <%= render "shared/chat_mine", chat: @chat, chat_color_class_name: "default", read_counts_hash: @read_counts_hash, remove_button: render("communities/chats/chat_remove_button", community: @community, chat: @chat) %>
   <% else %>
     <%= render "shared/chat_others", nickname: @user.profile.nickname, chat: @chat %>
   <% end %>

--- a/app/views/communities/chats/render_chat.turbo_stream.erb
+++ b/app/views/communities/chats/render_chat.turbo_stream.erb
@@ -3,7 +3,7 @@
     <%= render "shared/chat_date_block", date: @chat.created_at.to_date %>
   <% end %>
   <% if current_user == @user %>
-    <%= render "shared/chat_mine", chat: @chat, chat_color_class_name: "default", remove_button: nil %>
+    <%= render "shared/chat_mine", chat: @chat, chat_color_class_name: "default", read_counts_hash: nil, remove_button: render("communities/chats/chat_remove_button", community: @community, chat: @chat) %>
   <% else %>
     <%= render "shared/chat_others", nickname: @user.profile.nickname, chat: @chat %>
   <% end %>

--- a/app/views/communities/chats/render_chat.turbo_stream.erb
+++ b/app/views/communities/chats/render_chat.turbo_stream.erb
@@ -5,6 +5,6 @@
   <% if current_user == @user %>
     <%= render "shared/chat_mine", chat: @chat, chat_color_class_name: "default", read_counts_hash: @read_counts_hash, remove_button: render("communities/chats/chat_remove_button", community: @community, chat: @chat) %>
   <% else %>
-    <%= render "shared/chat_others", nickname: @user.profile.nickname, chat: @chat %>
+    <%= render "shared/chat_others", nickname: display_community_user_name(@user, [@user.id]), chat: @chat %>
   <% end %>
 <% end %>

--- a/app/views/machi_repos/chats/index.html.erb
+++ b/app/views/machi_repos/chats/index.html.erb
@@ -63,7 +63,7 @@
           <% previous_date = chat_date %>
 
           <% if current_user == chat.user %>
-            <%= render "shared/chat_mine", chat: chat, chat_color_class_name: "#{@machi_repo.info_level}", remove_button: render("machi_repos/chats/chat_remove_button", machi_repo: @machi_repo, chat: chat) %>
+            <%= render "shared/chat_mine", chat: chat, chat_color_class_name: "#{@machi_repo.info_level}", read_counts_hash: nil, remove_button: render("machi_repos/chats/chat_remove_button", machi_repo: @machi_repo, chat: chat) %>
           <% else %>
             <%= render "shared/chat_others", nickname: chat.user.profile.nickname, chat: chat %>
           <% end %>

--- a/app/views/machi_repos/chats/load_more.turbo_stream.erb
+++ b/app/views/machi_repos/chats/load_more.turbo_stream.erb
@@ -9,7 +9,7 @@
     <% previous_date = chat_date %>
 
     <% if current_user == chat.user %>
-      <%= render "shared/chat_mine", chat: chat, chat_color_class_name: "#{@machi_repo.info_level}", remove_button: render("machi_repos/chats/chat_remove_button", machi_repo: @machi_repo, chat: chat) %>
+      <%= render "shared/chat_mine", chat: chat, chat_color_class_name: "#{@machi_repo.info_level}", read_counts_hash: nil, remove_button: render("machi_repos/chats/chat_remove_button", machi_repo: @machi_repo, chat: chat) %>
     <% else %>
       <%= render "shared/chat_others", nickname: chat.user.profile.nickname, chat: chat %>
     <% end %>

--- a/app/views/machi_repos/chats/render_chat.turbo_stream.erb
+++ b/app/views/machi_repos/chats/render_chat.turbo_stream.erb
@@ -3,7 +3,7 @@
     <%= render "shared/chat_date_block", date: @chat.created_at.to_date %>
   <% end %>
   <% if current_user == @user %>
-    <%= render "shared/chat_mine", chat: @chat, chat_color_class_name: "#{@machi_repo.info_level}", remove_button: render("machi_repos/chats/chat_remove_button", machi_repo: @machi_repo, chat: @chat) %>
+    <%= render "shared/chat_mine", chat: @chat, chat_color_class_name: "#{@machi_repo.info_level}", read_counts_hash: nil, remove_button: render("machi_repos/chats/chat_remove_button", machi_repo: @machi_repo, chat: @chat) %>
   <% else %>
     <%= render "shared/chat_others", nickname: @user.profile.nickname, chat: @chat %>
   <% end %>

--- a/app/views/shared/_chat_date_block.html.erb
+++ b/app/views/shared/_chat_date_block.html.erb
@@ -1,4 +1,7 @@
-<div data-chat-date="<%= date %>" class="my-8 text-center">
+<div id="chat-date-<%= date %>"
+  class="my-8 text-center"
+  data-chat-date="<%= date %>"
+>
   <div class="inline-block rounded-2xl py-1 px-3 bg-black/50 text-white">
     <time class="chat-date">
       <%= I18n.l(date, format: :long) %>

--- a/app/views/shared/_chat_mine.html.erb
+++ b/app/views/shared/_chat_mine.html.erb
@@ -3,11 +3,14 @@
   id="chat_<%= chat&.id %>"
   class="chat <%= chat_color_class_name %>"
   data-chat-own="mine"
+  data-chat-id="<%= chat&.id %>"
 >
   <div class="chat-else">
-    <% if read_counts_hash.present? %>
-      <div>
-        <%= format_read_count(read_counts_hash[chat.id]&.size) %>
+    <% unless read_counts_hash.nil? %>
+      <div class="read-chat-count"
+        data-read-chat-count="<%= count = read_counts_hash[chat.id]&.size || 0 %>"
+      >
+        <%= format_read_count(count) %>
       </div>
     <% end %>
     <div class="chat-time">

--- a/app/views/shared/_chat_mine.html.erb
+++ b/app/views/shared/_chat_mine.html.erb
@@ -5,7 +5,11 @@
   data-chat-own="mine"
 >
   <div class="chat-else">
-    <div></div>
+    <% if read_counts_hash.present? %>
+      <div>
+        <%= format_read_count(read_counts_hash[chat.id]&.size) %>
+      </div>
+    <% end %>
     <div class="chat-time">
       <time><%= chat&.created_at&.strftime("%H:%M") %></time>
     </div>

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -46,19 +46,12 @@
       <%# コミュニティアイコン %>
       <li class="flex-1 text-black md:text-white">
         <%= link_to communities_path, class: "nav-icon #{"pointer-events-none" if current_page?(communities_path)}" do %>
-          <div class="w-10 aspect-square text-gray-300">
-            <%= render "shared/icons/handshake_full_icon" %>
-<%
-=begin
-%>
+          <div class="w-10 aspect-square">
             <% if current_page?(communities_path) %>
               <%= render "shared/icons/handshake_full_icon" %>
             <% else %>
               <%= render "shared/icons/handshake_icon" %>
             <% end %>
-<%
-=end
-%>
           </div>
           <span class="nav-text">コミュニティ</span>
         <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -77,6 +77,7 @@ Rails.application.routes.draw do
     resources :chats, only: %i[ index create destroy ], module: :communities do
       collection do
         get :load_more
+        patch :mark_as_read
       end
       member do
         get :render_chat

--- a/db/migrate/20250805015935_create_community_chat_reads.rb
+++ b/db/migrate/20250805015935_create_community_chat_reads.rb
@@ -1,0 +1,13 @@
+class CreateCommunityChatReads < ActiveRecord::Migration[8.0]
+  def change
+    create_table :community_chat_reads do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :community, null: false, foreign_key: true
+      t.integer :last_read_chat_id, null: false
+
+      t.timestamps
+    end
+
+    add_index :community_chat_reads, [ :user_id, :community_id ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_18_115614) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_05_015935) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -49,6 +49,17 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_18_115614) do
     t.index ["municipality_id"], name: "index_communities_on_municipality_id"
     t.index ["prefecture_id", "municipality_id", "name"], name: "idx_on_prefecture_id_municipality_id_name_7d0469a4b1", unique: true
     t.index ["prefecture_id"], name: "index_communities_on_prefecture_id"
+  end
+
+  create_table "community_chat_reads", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "community_id", null: false
+    t.integer "last_read_chat_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["community_id"], name: "index_community_chat_reads_on_community_id"
+    t.index ["user_id", "community_id"], name: "index_community_chat_reads_on_user_id_and_community_id", unique: true
+    t.index ["user_id"], name: "index_community_chat_reads_on_user_id"
   end
 
   create_table "community_memberships", force: :cascade do |t|
@@ -172,6 +183,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_18_115614) do
   add_foreign_key "chats", "users"
   add_foreign_key "communities", "municipalities"
   add_foreign_key "communities", "prefectures"
+  add_foreign_key "community_chat_reads", "communities"
+  add_foreign_key "community_chat_reads", "users"
   add_foreign_key "community_memberships", "communities"
   add_foreign_key "community_memberships", "users"
   add_foreign_key "follows", "users", column: "followed_id"


### PR DESCRIPTION
## 概要
- コミュニティのチャット機能に既読数を表示するようにした。
---
### 内容
- [x] CommunityChatReadモデルを作成した。
- [x] stimulusコントローラーchatにCommunityChatReadモデル登録用処理を追加した。
- [x] 自分のチャット用partialを修正した。
- [x] コミュニティの自主退会、強制退会時にCommunithiChatReadのデータを削除する処理を追加した。
- [x] チャットを削除後、同じ日付のものが１つもなくても日付表示が残ってしまっていたため、続けて投稿をすると日付が２つ表示されてしまうバグを修正した。